### PR TITLE
fixed incorrect links

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -59,7 +59,7 @@ const useNavItems = (): NavItem[] => {
     },
     {
         title: "Connectors",
-        path: "https://estuary.dev/sources/",
+        path: "https://estuary.dev/integrations/",
     },
     {
         title: "Resources",

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -366,7 +366,7 @@ const PricingPage = () => {
                                 </div>
                                 <Link
                                     className="pricing-page-tile-button"
-                                    to="https://github.com/estuary/flow"
+                                    to="https://dashboard.estuary.dev/register"
                                 >
                                     Get started
                                 </Link>
@@ -764,7 +764,7 @@ const PricingPage = () => {
                                 </OutboundLink>
                                 <OutboundLink
                                     target="_blank"
-                                    href="/why"
+                                    href="/about#contact-us"
                                     className="demo-button"
                                 >
                                     Contact Us


### PR DESCRIPTION
Fixed incorrect links for:

1. Navbar "Connectors", goes to /integrations now, was going to /sources
2. Bottom "Contact Us" on /pricing was going to /why, now goes to /about#contact-us, like the top Contact Us button
3. Free plan card "Get started" link was going to the flow github repo, now goes to /register as it should