### PR TITLE
Fix: Source pages description typo

### DIFF
--- a/src/components/ConnectorPage.tsx
+++ b/src/components/ConnectorPage.tsx
@@ -83,7 +83,7 @@ export const ConnectorPage = ({
                             <span>
                                 Estuary builds free, open-source connectors to{" "}
                                 {connector_type === "capture"
-                                    ? `extract data from ${source_mapped.title}`
+                                    ? `extract data from ${source_mapped.title} `
                                     : connector_type === "materialization"
                                     ? `write data to ${dest_mapped.title}`
                                     : `move data from ${source_mapped.title} to ${dest_mapped.title}`}


### PR DESCRIPTION
## Changes

- Changed the template string to add a blank space after the `source_mapped.title`

## Tests / Screenshots
![image](https://github.com/estuary/marketing-site/assets/40703179/c8da6854-fd60-4f90-b040-22deaefc6203)