### PR TITLE
Removing the old links and setting back to the demo

### DIFF
--- a/src/components/TakeATour/index.tsx
+++ b/src/components/TakeATour/index.tsx
@@ -4,30 +4,32 @@ import CloseIcon from '@mui/icons-material/Close';
 
 import { Button, Container, Link } from './styles';
 
-const STORAGE_NAME = '@estuary/closeTour';
-
-// If there is an upcoming webinar: `webinar_{date}`
-// If there is no webinar: `demo`
-const LATEST_VERSION = 'demo';
-
-// defaults
-// href: '/why',
-// message: 'Take a Product Tour',
-const SETTINGS = {
+const DEFAULTS = {
   href: '/why',
   message: 'Take a Product Tour',
+  version: '',
 };
+
+const SETTINGS = {
+  ...DEFAULTS,
+  // When there is a webinar uncomment below and provide the necessary details
+  // href: 'fake/path/name',
+  // message: 'This is a fake future Webinar',
+  // version: `/webinar_YYYY/MM/DD`,
+};
+
+const STORAGE_KEY = `@estuary/closeTour${SETTINGS.version}`;
 
 const TakeATour = () => {
   const [closeTour, setCloseTour] = useState(true);
 
   const onClick = useCallback(() => {
-    localStorage.setItem(`${STORAGE_NAME}_${LATEST_VERSION}`, '1');
+    localStorage.setItem(STORAGE_KEY, '1');
     setCloseTour(true);
   }, []);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') setCloseTour(!!localStorage.getItem(STORAGE_NAME));
+    if (typeof window !== 'undefined') setCloseTour(!!localStorage.getItem(STORAGE_KEY));
   }, []);
 
   if (closeTour) return null;

--- a/src/components/TakeATour/index.tsx
+++ b/src/components/TakeATour/index.tsx
@@ -6,11 +6,23 @@ import { Button, Container, Link } from './styles';
 
 const STORAGE_NAME = '@estuary/closeTour';
 
+// If there is an upcoming webinar: `webinar_{date}`
+// If there is no webinar: `demo`
+const LATEST_VERSION = 'demo';
+
+// defaults
+// href: '/why',
+// message: 'Take a Product Tour',
+const SETTINGS = {
+  href: '/why',
+  message: 'Take a Product Tour',
+};
+
 const TakeATour = () => {
   const [closeTour, setCloseTour] = useState(true);
 
   const onClick = useCallback(() => {
-    localStorage.setItem(STORAGE_NAME, '1');
+    localStorage.setItem(`${STORAGE_NAME}_${LATEST_VERSION}`, '1');
     setCloseTour(true);
   }, []);
 
@@ -22,8 +34,8 @@ const TakeATour = () => {
 
   return (
     <Container>
-      <Link target="_blank" href="https://try.estuary.dev/how-to-build-an-ai-pipeline/">
-        "How to Build Pipelines for Gen AI" - Join our April 10th webinar
+      <Link target="_blank" href={SETTINGS.href}>
+        {SETTINGS.message}
       </Link>
       <Button onClick={onClick}>
         <CloseIcon color="inherit" fontSize="small" />

--- a/src/components/TakeATour/index.tsx
+++ b/src/components/TakeATour/index.tsx
@@ -1,8 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
-
-import CloseIcon from '@mui/icons-material/Close';
-
 import { Button, Container, Link } from './styles';
+import React, { useCallback, useEffect, useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
 
 const DEFAULTS = {
   href: '/why',


### PR DESCRIPTION
Also preparing for this to open the banner again when things change

## Changes

- Remove Feb 10 webinar link
- Add back in link to `Demo`
- Add support for the banner to open when a new webinar is added

## Tests / Screenshots

- Manually hit the home page. Nothing shows because I had dismissed it and we still use the old key to check if the user has dismissed already
![image](https://github.com/estuary/marketing-site/assets/270078/96154c53-2e09-4db7-bb9a-c132b6939a0d)

- Altered the value to cause the demo to show up
![image](https://github.com/estuary/marketing-site/assets/270078/3397866b-1d5c-4ce4-a1f1-e22245507ff2)

- Added a fake webinar
![image](https://github.com/estuary/marketing-site/assets/270078/4a7e4e7c-17d8-4353-a65c-0ec346e1aff6)
![image](https://github.com/estuary/marketing-site/assets/270078/3a119df9-24de-419c-a267-0e11ef2c9168)



