### PR TITLE
Fix tags not jumping to the next row

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -6159,6 +6159,7 @@ table th {
     .tags-wrapper {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: 10px;
     }
 


### PR DESCRIPTION
## Changes

-   Add flex wrap: wrap to the tags in the blog post template

## Tests / Screenshots

-   scenarios you tested with screenshots

Not flexible tags avoiding image to be displayed totally:
![Screen Shot 2024-04-18 at 6 25 19 PM](https://github.com/estuary/marketing-site/assets/60396753/03c119cd-5a29-4a87-b09d-92fcf0584e79)

