### PR TITLE
Brenosalv/bug/fix-blog-post-popup-hidden-by-page-header

### DIFF
--- a/src/components/BlogPopularArticles.tsx
+++ b/src/components/BlogPopularArticles.tsx
@@ -79,9 +79,9 @@ export const PopularArticles = () => {
                                             <span className="article-card-published-at">
                                                 {article?.updatedAt}
                                             </span>
-                                            <div className="dot" />
+                                            {/* <div className="dot" /> */}
                                             {/* TODO: Add post reading time from Strapi */}
-                                            <span>10 min</span>
+                                            {/* <span>10 min</span> */}
                                         </div>
                                     </div>
                                     <h4>{article?.title}</h4>

--- a/src/components/BlogPostPopupModal/styles.ts
+++ b/src/components/BlogPostPopupModal/styles.ts
@@ -14,6 +14,8 @@ export const Container = styled(Dialog)`
     padding: 0;
     font-family: "Inter", sans-serif;
     color: #ffffff;
+    margin-top: 124px;
+    max-height: calc(100% - 160px);
 
     @media (max-width: 1024px) {
       width: 90%;
@@ -22,8 +24,6 @@ export const Container = styled(Dialog)`
     @media (max-width: 780px) {
       grid-template-columns: 1fr;
       grid-template-rows: 1fr auto;
-      margin-top: 124px;
-      max-height: calc(100% - 160px);
     }
   }
 `

--- a/src/components/BlogPostPopupModal/styles.ts
+++ b/src/components/BlogPostPopupModal/styles.ts
@@ -16,6 +16,7 @@ export const Container = styled(Dialog)`
     color: #ffffff;
     margin-top: 124px;
     max-height: calc(100% - 160px);
+    min-height: 100px;
 
     @media (max-width: 1024px) {
       width: 90%;


### PR DESCRIPTION
## Changes

-   Add margin top and max height in all the devices instead of only mobile ones.

## Tests / Screenshots

-   Now it's considering the header and not hidden behind it even for screens with low heights:
![image](https://github.com/estuary/marketing-site/assets/60396753/00b47766-ffa1-4a16-95ca-131a7ad7d79a)

