### PR TITLE
Adding missing page titles

### DIFF
--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,106 +1,322 @@
-import * as React from "react";
-import Layout from "../components/layout";
-import { OutboundLink } from "../components/OutboundLink";
+import * as React from 'react';
+import Layout from '../components/layout';
+import { OutboundLink } from '../components/OutboundLink';
+import Seo from '../components/seo';
+
+export const Head = () => <Seo title="Privacy Policy" />;
 
 const PrivacyPolicy = () => {
-    return (
-        <Layout headerTheme="light">
-            <div className="privacy-policy-root">
-                <h2>Privacy Policy</h2>
-                <h5>We respect your privacy.</h5>
-                <p>Estuary Technologies, Inc. ("<span className="privacy-underline">Estuary</span>,” “<span className="privacy-underline">we</span>,” “<span className="privacy-underline">us</span>,” or “<span className="privacy-underline">our</span>”) welcomes you. Our collection and use of information from visitors of our Website and Customers of our Product and related services (collectively with the Website and Product, the “<span className="privacy-underline">Services</span>”) is subject to the following privacy policy (the “<span className="privacy-underline">Privacy Policy</span>”), which may be updated by us from time to time without notice to you.</p>
-                <p>By visiting our Website, visitors are agreeing to the terms of this Privacy Policy and the accompanying Terms of Use.
-                </p>
-                <p>By using the Website or when you sign up to access and use the Services, you acknowledge that you have read, understood and agree to be legally bound by the terms of this Privacy Policy, the accompanying Terms of Use. If you do not agree to (or cannot comply with) all of the terms of this Privacy Policy and the Terms of Use, you may not access or use the Services.</p>
-                <p>If you accept or agree to this Agreement on behalf of a company or other legal entity, you represent and warrant that you have the authority to bind that company or other legal entity to the Agreement and, in such event, “<span className="privacy-underline">you</span>” and “<span className="privacy-underline">your</span>” will refer and apply to that company or other legal entity and any Authorized Users.</p>
-                <p>Capitalized terms not defined in this Privacy Policy shall have the meaning set forth in our Terms of Use or the Master Software Agreement, as applicable.</p>
+  return (
+    <Layout headerTheme="light">
+      <div className="privacy-policy-root">
+        <h2>Privacy Policy</h2>
+        <h5>We respect your privacy.</h5>
+        <p>
+          Estuary Technologies, Inc. ("<span className="privacy-underline">Estuary</span>,” “
+          <span className="privacy-underline">we</span>,” “<span className="privacy-underline">us</span>,” or “
+          <span className="privacy-underline">our</span>”) welcomes you. Our collection and use of information from
+          visitors of our Website and Customers of our Product and related services (collectively with the Website and
+          Product, the “<span className="privacy-underline">Services</span>”) is subject to the following privacy policy
+          (the “<span className="privacy-underline">Privacy Policy</span>”), which may be updated by us from time to
+          time without notice to you.
+        </p>
+        <p>
+          By visiting our Website, visitors are agreeing to the terms of this Privacy Policy and the accompanying Terms
+          of Use.
+        </p>
+        <p>
+          By using the Website or when you sign up to access and use the Services, you acknowledge that you have read,
+          understood and agree to be legally bound by the terms of this Privacy Policy, the accompanying Terms of Use.
+          If you do not agree to (or cannot comply with) all of the terms of this Privacy Policy and the Terms of Use,
+          you may not access or use the Services.
+        </p>
+        <p>
+          If you accept or agree to this Agreement on behalf of a company or other legal entity, you represent and
+          warrant that you have the authority to bind that company or other legal entity to the Agreement and, in such
+          event, “<span className="privacy-underline">you</span>” and “<span className="privacy-underline">your</span>”
+          will refer and apply to that company or other legal entity and any Authorized Users.
+        </p>
+        <p>
+          Capitalized terms not defined in this Privacy Policy shall have the meaning set forth in our Terms of Use or
+          the Master Software Agreement, as applicable.
+        </p>
 
-                <p className="privacy-underline privacy-bold">THE INFORMATION WE COLLECT AND HOW WE USE IT</p>
-                <p>In the course of operating the Services, Estuary collects or receives the following types of information from you, which may include personal information.</p>
+        <p className="privacy-underline privacy-bold">THE INFORMATION WE COLLECT AND HOW WE USE IT</p>
+        <p>
+          In the course of operating the Services, Estuary collects or receives the following types of information from
+          you, which may include personal information.
+        </p>
 
-                <p className="privacy-bold">Contact Information</p>
-                <p>We collect contact information through our Services; contact information typically includes your name, email address, and any information you provide in messages to us. We use such contact information for purposes such as providing you with information about the Services, responding to your inquiries, sending you email alerts (including marketing emails), registering you as an Authorized User of the Product, and providing you the Services.</p>
+        <p className="privacy-bold">Contact Information</p>
+        <p>
+          We collect contact information through our Services; contact information typically includes your name, email
+          address, and any information you provide in messages to us. We use such contact information for purposes such
+          as providing you with information about the Services, responding to your inquiries, sending you email alerts
+          (including marketing emails), registering you as an Authorized User of the Product, and providing you the
+          Services.
+        </p>
 
-                <p className="privacy-bold">Payment Information</p>
-                <p>If you purchase the Product, to process your payment you will be required to provide to us certain billing information, which may include providing a credit card number, expiration date, bank account information, billing address, activation code, and similar information (collectively, “<span className="privacy-underline">Payment Information</span>”). You authorize our third-party payment vendors including, without limitation, Stripe, to collect, process, and store such Payment Information in accordance with their respective privacy policies. We reserve the right to change our payment vendors at any time, or to use additional payment vendors, at our discretion, and will update this Privacy Policy from time to time accordingly. By purchasing the Product, you agree to be bound by Stripe’s terms and conditions and privacy policy, which are available at https://stripe.com/legal and https://stripe.com/us/privacy, respectively.</p>
+        <p className="privacy-bold">Payment Information</p>
+        <p>
+          If you purchase the Product, to process your payment you will be required to provide to us certain billing
+          information, which may include providing a credit card number, expiration date, bank account information,
+          billing address, activation code, and similar information (collectively, “
+          <span className="privacy-underline">Payment Information</span>”). You authorize our third-party payment
+          vendors including, without limitation, Stripe, to collect, process, and store such Payment Information in
+          accordance with their respective privacy policies. We reserve the right to change our payment vendors at any
+          time, or to use additional payment vendors, at our discretion, and will update this Privacy Policy from time
+          to time accordingly. By purchasing the Product, you agree to be bound by Stripe’s terms and conditions and
+          privacy policy, which are available at https://stripe.com/legal and https://stripe.com/us/privacy,
+          respectively.
+        </p>
 
-                <p className="privacy-bold">Activity Information</p>
-                <p>We will have access to any Customer Content that you submit to us for our portability services. Customer content includes: (i) the data that Customer, or its Client, as applicable, requests Estuary to transfer from one system to another, (ii) configuration information to connect to the relevant systems, such as passwords and user identifications, and (iii) other information provided to Estuary to help configure how and when the data transfer will occur, such as notification preferences. We only access and use the Customer Content to provide you the data portability services.</p>
+        <p className="privacy-bold">Activity Information</p>
+        <p>
+          We will have access to any Customer Content that you submit to us for our portability services. Customer
+          content includes: (i) the data that Customer, or its Client, as applicable, requests Estuary to transfer from
+          one system to another, (ii) configuration information to connect to the relevant systems, such as passwords
+          and user identifications, and (iii) other information provided to Estuary to help configure how and when the
+          data transfer will occur, such as notification preferences. We only access and use the Customer Content to
+          provide you the data portability services.
+        </p>
 
-                <p className="privacy-bold">Server Log Information</p>
-                <p>Our servers keep log files that record data each time a device accesses those servers. The log files contain data about the nature of such access, including the device’s IP address, user agent string (e.g., operating system and browser type/version), and the pages you’ve clicked on while on our Services, and details regarding your activity on the Services such as time spent on the Services and other similar data with respect to how you use the Services. We may use these log files for purposes such as assisting in monitoring and troubleshooting errors and incidents, analyzing traffic, or optimizing the user experience.</p>
+        <p className="privacy-bold">Server Log Information</p>
+        <p>
+          Our servers keep log files that record data each time a device accesses those servers. The log files contain
+          data about the nature of such access, including the device’s IP address, user agent string (e.g., operating
+          system and browser type/version), and the pages you’ve clicked on while on our Services, and details regarding
+          your activity on the Services such as time spent on the Services and other similar data with respect to how
+          you use the Services. We may use these log files for purposes such as assisting in monitoring and
+          troubleshooting errors and incidents, analyzing traffic, or optimizing the user experience.
+        </p>
 
-                <p className="privacy-bold">Cookies</p>
-                <p>We may collect information using “cookie” and other similar technologies. Cookies are small packets of data that a website stores on your computer’s or mobile device’s hard drive (or other storage medium) so that your computer will “remember” information about your use. We use both first and third party session cookies and persistent cookies. Below is a general primer on session and persistent cookies; information collected by cookies depends on its particular purpose. For more information, please see the information regarding analytics providers discussed further below.</p>
-                <ul>
-                    <li><span className="privacy-bold">Session Cookies:</span> We use session cookies to make it easier for you to navigate our Services. A session ID cookie expires when you close the Services.</li>
-                    <li><span className="privacy-bold">Persistent Cookies:</span> A persistent cookie remains on your device for an extended period of time or until you delete them. Persistent cookies enable us to track and target the interests of our visitors to personalize the experience on our Services. Also, to the extent we provide a log-in portal or related feature on our Services, persistent cookies can be used to store your passwords so that you don’t have to enter it more than once.</li>
-                </ul>
-                <p>If you do not want us to place a cookie on your device, you may be able to turn that feature off on your device. Please consult your browser’s documentation for information on how to do this and how to delete persistent cookies. However, if you decide not to accept cookies from us, certain aspects of the Services may not function properly or as intended.</p>
+        <p className="privacy-bold">Cookies</p>
+        <p>
+          We may collect information using “cookie” and other similar technologies. Cookies are small packets of data
+          that a website stores on your computer’s or mobile device’s hard drive (or other storage medium) so that your
+          computer will “remember” information about your use. We use both first and third party session cookies and
+          persistent cookies. Below is a general primer on session and persistent cookies; information collected by
+          cookies depends on its particular purpose. For more information, please see the information regarding
+          analytics providers discussed further below.
+        </p>
+        <ul>
+          <li>
+            <span className="privacy-bold">Session Cookies:</span> We use session cookies to make it easier for you to
+            navigate our Services. A session ID cookie expires when you close the Services.
+          </li>
+          <li>
+            <span className="privacy-bold">Persistent Cookies:</span> A persistent cookie remains on your device for an
+            extended period of time or until you delete them. Persistent cookies enable us to track and target the
+            interests of our visitors to personalize the experience on our Services. Also, to the extent we provide a
+            log-in portal or related feature on our Services, persistent cookies can be used to store your passwords so
+            that you don’t have to enter it more than once.
+          </li>
+        </ul>
+        <p>
+          If you do not want us to place a cookie on your device, you may be able to turn that feature off on your
+          device. Please consult your browser’s documentation for information on how to do this and how to delete
+          persistent cookies. However, if you decide not to accept cookies from us, certain aspects of the Services may
+          not function properly or as intended.
+        </p>
 
-                <p className="privacy-bold">Third-Party Analytics Providers</p>
-                <p>We use one or more third–party analytics services to evaluate your use of the Services, as the case may be, by compiling reports on activity (based on their collection of IP addresses, Internet service provider, browser type, operating system and language, referring and exit pages and URLs, data and time, amount of time spent on particular pages, what sections of the Services you visit, number of links clicked, search terms and other similar data with respect to how you use the Services) and analyzing performance metrics. These third parties use cookies and other technologies to help collect, analyze, and provide us reports or other data.</p>
-                <p>By accessing and using the Services, you consent to the processing of data about you by these analytics providers in the manner and for the purposes set out in this Privacy Policy. For more information on these third parties, including how to opt out from certain data collection, please visit the sites below. Please be advised that if you opt out of any service, you may not be able to use the full functionality of the Services.</p>
+        <p className="privacy-bold">Third-Party Analytics Providers</p>
+        <p>
+          We use one or more third–party analytics services to evaluate your use of the Services, as the case may be, by
+          compiling reports on activity (based on their collection of IP addresses, Internet service provider, browser
+          type, operating system and language, referring and exit pages and URLs, data and time, amount of time spent on
+          particular pages, what sections of the Services you visit, number of links clicked, search terms and other
+          similar data with respect to how you use the Services) and analyzing performance metrics. These third parties
+          use cookies and other technologies to help collect, analyze, and provide us reports or other data.
+        </p>
+        <p>
+          By accessing and using the Services, you consent to the processing of data about you by these analytics
+          providers in the manner and for the purposes set out in this Privacy Policy. For more information on these
+          third parties, including how to opt out from certain data collection, please visit the sites below. Please be
+          advised that if you opt out of any service, you may not be able to use the full functionality of the Services.
+        </p>
 
-                <p>For Google Analytics, please visit: <OutboundLink href="https://www.google.com/analytics">https://www.google.com/analytics</OutboundLink></p>
-                <p>For Hotjar, please visit: <OutboundLink href="https://www.hotjar.com/legal/policies/privacy/">https://www.hotjar.com/legal/policies/privacy/</OutboundLink></p>
-                <p>For Mailchimp please visit: <OutboundLink href="https://mailchimp.com/legal/privacy/">https://mailchimp.com/legal/privacy/</OutboundLink></p>
-                <p>For HubSpot please visit: <OutboundLink href="https://legal.hubspot.com/privacy-policy">https://legal.hubspot.com/privacy-policy</OutboundLink></p>
+        <p>
+          For Google Analytics, please visit:{' '}
+          <OutboundLink href="https://www.google.com/analytics">https://www.google.com/analytics</OutboundLink>
+        </p>
+        <p>
+          For Hotjar, please visit:{' '}
+          <OutboundLink href="https://www.hotjar.com/legal/policies/privacy/">
+            https://www.hotjar.com/legal/policies/privacy/
+          </OutboundLink>
+        </p>
+        <p>
+          For Mailchimp please visit:{' '}
+          <OutboundLink href="https://mailchimp.com/legal/privacy/">https://mailchimp.com/legal/privacy/</OutboundLink>
+        </p>
+        <p>
+          For HubSpot please visit:{' '}
+          <OutboundLink href="https://legal.hubspot.com/privacy-policy">
+            https://legal.hubspot.com/privacy-policy
+          </OutboundLink>
+        </p>
 
-                <p className="privacy-bold">Third-Party OAuth Providers</p>
-                <p>The use and transfer of information received from Google APIs to any other app will adhere to <OutboundLink href="https://developers.google.com/terms/api-services-user-data-policy">Google API Services User Data Policy</OutboundLink>, including the Limited Use requirements.</p>
-                
-                <p className="privacy-bold">Aggregate Data</p>
-                <p>In an ongoing effort to better understand our users and the Services, we might analyze data with respect to how you use the Services, including Usage Data, alone and in combination with other data (including anonymized elements of the Customer Content), and may use such combined data in an aggregate and anonymous manner to operate, maintain, manage, and improve the Services. This aggregate information does not identify you personally. We may share this aggregate data with our affiliates, agents, and business partners. We may also disclose aggregated user statistics to describe the Services to current and prospective business partners and to other third parties for other lawful purposes.</p>
+        <p className="privacy-bold">Third-Party OAuth Providers</p>
+        <p>
+          The use and transfer of information received from Google APIs to any other app will adhere to{' '}
+          <OutboundLink href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </OutboundLink>
+          , including the Limited Use requirements.
+        </p>
 
-                <p className="privacy-bold">Onward Transfer to Third Parties</p>
-                <ul>
-                    <li>Like many businesses, we hire other companies to perform certain business-related services. We may disclose personal information to certain types of third party companies but only to the extent needed to enable them to provide such services. The types of companies that may receive personal information and their functions are: hosting services, technical assistance, database management/back-up services, usage analytics, email marketing platforms, customer service, collaboration services, authentication services, and authorization services.</li>
-                    <li>To provide our Services and administer promotional programs, we may share your personal information with our third-party promotional and marketing partners, including, without limitation, businesses participating in our various programs.</li>
-                    <li>We may, from time to time, share and/or license personal information to other companies who may provide you information about the products and services they or their partners offer. However, to the extent required by law, you will be given the opportunity to opt out of such sharing.</li>
-                    <li>We may share personal information and Customer Content with third party systems in connection with the Services and to enable use of the Product, such as when you use the Product to move data to or from one system to another.</li>
-                    <li>We may also disclose personal information to our parent companies, subsidiaries, affiliates, joint ventures, or other companies under common control to support the marketing and sale of our products and services.</li>
-                </ul>
+        <p className="privacy-bold">Aggregate Data</p>
+        <p>
+          In an ongoing effort to better understand our users and the Services, we might analyze data with respect to
+          how you use the Services, including Usage Data, alone and in combination with other data (including anonymized
+          elements of the Customer Content), and may use such combined data in an aggregate and anonymous manner to
+          operate, maintain, manage, and improve the Services. This aggregate information does not identify you
+          personally. We may share this aggregate data with our affiliates, agents, and business partners. We may also
+          disclose aggregated user statistics to describe the Services to current and prospective business partners and
+          to other third parties for other lawful purposes.
+        </p>
 
-                <p className="privacy-bold">Business Transfers</p>
-                <p>In the event of a merger, dissolution, reorganization or similar corporate event, or the sale of all or substantially all of our assets, we expect that the information that we have collected, including personal information, would be transferred to the surviving entity in a merger or the acquiring entity. All such transfers shall be subject to our commitments with respect to the privacy and confidentiality of such personal information as set forth in this Privacy Policy. This policy shall be binding upon Estuary and its legal successors in interest.</p>
+        <p className="privacy-bold">Onward Transfer to Third Parties</p>
+        <ul>
+          <li>
+            Like many businesses, we hire other companies to perform certain business-related services. We may disclose
+            personal information to certain types of third party companies but only to the extent needed to enable them
+            to provide such services. The types of companies that may receive personal information and their functions
+            are: hosting services, technical assistance, database management/back-up services, usage analytics, email
+            marketing platforms, customer service, collaboration services, authentication services, and authorization
+            services.
+          </li>
+          <li>
+            To provide our Services and administer promotional programs, we may share your personal information with our
+            third-party promotional and marketing partners, including, without limitation, businesses participating in
+            our various programs.
+          </li>
+          <li>
+            We may, from time to time, share and/or license personal information to other companies who may provide you
+            information about the products and services they or their partners offer. However, to the extent required by
+            law, you will be given the opportunity to opt out of such sharing.
+          </li>
+          <li>
+            We may share personal information and Customer Content with third party systems in connection with the
+            Services and to enable use of the Product, such as when you use the Product to move data to or from one
+            system to another.
+          </li>
+          <li>
+            We may also disclose personal information to our parent companies, subsidiaries, affiliates, joint ventures,
+            or other companies under common control to support the marketing and sale of our products and services.
+          </li>
+        </ul>
 
-                <p className="privacy-bold">Disclosure to Public Authorities</p>
-                <p>We are required to disclose personal information in response to lawful requests by public authorities, including for the purpose of meeting national security or law enforcement requirements. We may also disclose personal information to other third parties when compelled to do so by government authorities or required by law or regulation including, but not limited to, in response to court orders and subpoenas.</p>
+        <p className="privacy-bold">Business Transfers</p>
+        <p>
+          In the event of a merger, dissolution, reorganization or similar corporate event, or the sale of all or
+          substantially all of our assets, we expect that the information that we have collected, including personal
+          information, would be transferred to the surviving entity in a merger or the acquiring entity. All such
+          transfers shall be subject to our commitments with respect to the privacy and confidentiality of such personal
+          information as set forth in this Privacy Policy. This policy shall be binding upon Estuary and its legal
+          successors in interest.
+        </p>
 
-                <p className="privacy-underline privacy-bold">OPT-OUT FOR DIRECT MARKETING; EMAIL MANAGEMENT</p>
-                <p>You may opt out at any time from the use of your personal information for direct marketing purposes by emailing the instructions to <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> or by clicking on the “Unsubscribe” link located on the bottom of any Estuary marketing email and following the instructions found on the page to which the link takes you. Please allow us a reasonable time to process your request. You cannot opt out of receiving transactional e-mails related to the Services.</p>
+        <p className="privacy-bold">Disclosure to Public Authorities</p>
+        <p>
+          We are required to disclose personal information in response to lawful requests by public authorities,
+          including for the purpose of meeting national security or law enforcement requirements. We may also disclose
+          personal information to other third parties when compelled to do so by government authorities or required by
+          law or regulation including, but not limited to, in response to court orders and subpoenas.
+        </p>
 
-                <p className="privacy-underline privacy-bold">HOW WE PROTECT YOUR INFORMATION</p>
-                <p>Estuary takes very seriously the security and privacy of the personal information that it collects pursuant to this Privacy Policy. Accordingly, we implement reasonable security measures designed to protect your personal information from loss, misuse and unauthorized access, disclosure, alteration and destruction, taking into account the risks involved in processing and the nature of such data, and to comply with applicable laws and regulations. Please understand, however, that no security system is impenetrable. We cannot guarantee the security of our databases or the databases of the third parties with which we may share your information (as permitted herein), nor can we guarantee that the information you supply will not be intercepted while being transmitted over the Internet. In particular, e-mail sent to us may not be secure, and you should therefore take special care in deciding what information you send to us via e-mail.</p>
+        <p className="privacy-underline privacy-bold">OPT-OUT FOR DIRECT MARKETING; EMAIL MANAGEMENT</p>
+        <p>
+          You may opt out at any time from the use of your personal information for direct marketing purposes by
+          emailing the instructions to <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> or by clicking on
+          the “Unsubscribe” link located on the bottom of any Estuary marketing email and following the instructions
+          found on the page to which the link takes you. Please allow us a reasonable time to process your request. You
+          cannot opt out of receiving transactional e-mails related to the Services.
+        </p>
 
-                <p className="privacy-underline privacy-bold">CHILDREN</p>
-                <p>We do not knowingly collect personal information from children under the age of 13 through the Services. If you are under 13, please do not give us any personal information. We encourage parents and legal guardians to monitor their children’s Internet usage and to help enforce our Privacy Policy by instructing their children to never provide personal information without their permission. If you have reason to believe that a child under the age of 13 has provided personal information to us, please contact us at <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a>, and we will endeavor to delete that information from our databases.</p>
+        <p className="privacy-underline privacy-bold">HOW WE PROTECT YOUR INFORMATION</p>
+        <p>
+          Estuary takes very seriously the security and privacy of the personal information that it collects pursuant to
+          this Privacy Policy. Accordingly, we implement reasonable security measures designed to protect your personal
+          information from loss, misuse and unauthorized access, disclosure, alteration and destruction, taking into
+          account the risks involved in processing and the nature of such data, and to comply with applicable laws and
+          regulations. Please understand, however, that no security system is impenetrable. We cannot guarantee the
+          security of our databases or the databases of the third parties with which we may share your information (as
+          permitted herein), nor can we guarantee that the information you supply will not be intercepted while being
+          transmitted over the Internet. In particular, e-mail sent to us may not be secure, and you should therefore
+          take special care in deciding what information you send to us via e-mail.
+        </p>
 
-                <p className="privacy-underline privacy-bold">IMPORTANT NOTICE TO ALL NON-US RESIDENTS</p>
-                <p>Our servers are located in the US and elsewhere. Please be aware that your information may be transferred to, processed, maintained, and used on computers, servers, and systems located outside of your state, province, country, or other governmental jurisdiction where the privacy laws may not be as protective as those in your country of origin. If you are located outside the United States and choose to use the Services, you do so at your own risk.</p>
+        <p className="privacy-underline privacy-bold">CHILDREN</p>
+        <p>
+          We do not knowingly collect personal information from children under the age of 13 through the Services. If
+          you are under 13, please do not give us any personal information. We encourage parents and legal guardians to
+          monitor their children’s Internet usage and to help enforce our Privacy Policy by instructing their children
+          to never provide personal information without their permission. If you have reason to believe that a child
+          under the age of 13 has provided personal information to us, please contact us at{' '}
+          <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a>, and we will endeavor to delete that information
+          from our databases.
+        </p>
 
-                <p className="privacy-underline privacy-bold">CALIFORNIA PRIVACY RIGHTS</p>
-                <p>Pursuant to Section 1798.83 of the California Civil Code, residents of California have the right to obtain certain information about the types of personal information that companies with whom they have an established business relationship (and that are not otherwise exempt) have shared with third parties for direct marketing purposes during the preceding calendar year, including the names and addresses of those third parties, and examples of the types of services or products marketed by those third parties. If you wish to submit a request pursuant to Section 1798.83, please contact Estuary via email at <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a>.</p>
+        <p className="privacy-underline privacy-bold">IMPORTANT NOTICE TO ALL NON-US RESIDENTS</p>
+        <p>
+          Our servers are located in the US and elsewhere. Please be aware that your information may be transferred to,
+          processed, maintained, and used on computers, servers, and systems located outside of your state, province,
+          country, or other governmental jurisdiction where the privacy laws may not be as protective as those in your
+          country of origin. If you are located outside the United States and choose to use the Services, you do so at
+          your own risk.
+        </p>
 
-                <p className="privacy-underline privacy-bold">DO NOT TRACK</p>
-                <p>Estuary does not respond to “Do Not Track” settings or other related mechanisms at this time.</p>
+        <p className="privacy-underline privacy-bold">CALIFORNIA PRIVACY RIGHTS</p>
+        <p>
+          Pursuant to Section 1798.83 of the California Civil Code, residents of California have the right to obtain
+          certain information about the types of personal information that companies with whom they have an established
+          business relationship (and that are not otherwise exempt) have shared with third parties for direct marketing
+          purposes during the preceding calendar year, including the names and addresses of those third parties, and
+          examples of the types of services or products marketed by those third parties. If you wish to submit a request
+          pursuant to Section 1798.83, please contact Estuary via email at{' '}
+          <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a>.
+        </p>
 
-                <p className="privacy-underline privacy-bold">NEVADA PRIVACY RIGHTS</p>
-                <p>If you are a resident of Nevada, you have the right to opt-out of the sale of certain personal information to third parties who intend to license or sell that personal information. You can exercise this right by contacting us at <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> with the subject line “Nevada Do Not Sell Request” and providing us with your name and the email address associated with your account. Please note that we do not currently sell your personal information as sales are defined in Nevada Revised Statutes Chapter 603A.</p>
+        <p className="privacy-underline privacy-bold">DO NOT TRACK</p>
+        <p>Estuary does not respond to “Do Not Track” settings or other related mechanisms at this time.</p>
 
-                <p className="privacy-underline privacy-bold">LINKS TO EXTERNAL WEBSITES</p>
-                <p>The Services may contain links to third-party websites (“External Sites”). Estuary has no control over the privacy practices or the content of any such External Sites. As such, we are not responsible for the content or the privacy policies of such External Sites. You should check the applicable privacy policy and terms of use when visiting any such External Sites.</p>
+        <p className="privacy-underline privacy-bold">NEVADA PRIVACY RIGHTS</p>
+        <p>
+          If you are a resident of Nevada, you have the right to opt-out of the sale of certain personal information to
+          third parties who intend to license or sell that personal information. You can exercise this right by
+          contacting us at <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> with the subject line “Nevada Do
+          Not Sell Request” and providing us with your name and the email address associated with your account. Please
+          note that we do not currently sell your personal information as sales are defined in Nevada Revised Statutes
+          Chapter 603A.
+        </p>
 
-                <p className="privacy-underline privacy-bold">CHANGES TO THIS PRIVACY POLICY</p>
-                <p>This Privacy Policy is effective as of the last updated date stated at the top of this Privacy Policy. We may change this Privacy Policy from time to time with or without notice to you. By accessing the Services after we make any such changes to this Privacy Policy, you are deemed to have accepted such changes. Please be aware that, to the extent permitted by applicable law, our use of the information collected is governed by the Privacy Policy in effect at the time we collect the information. Please refer back to this Privacy Policy on a regular basis.</p>
+        <p className="privacy-underline privacy-bold">LINKS TO EXTERNAL WEBSITES</p>
+        <p>
+          The Services may contain links to third-party websites (“External Sites”). Estuary has no control over the
+          privacy practices or the content of any such External Sites. As such, we are not responsible for the content
+          or the privacy policies of such External Sites. You should check the applicable privacy policy and terms of
+          use when visiting any such External Sites.
+        </p>
 
-                <p className="privacy-underline privacy-bold">CHANGES TO THIS PRIVACY POLICY</p>
-                <p>If you have questions about this Privacy Policy, please e-mail us at <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> with “Privacy Policy” in the subject line.</p>
+        <p className="privacy-underline privacy-bold">CHANGES TO THIS PRIVACY POLICY</p>
+        <p>
+          This Privacy Policy is effective as of the last updated date stated at the top of this Privacy Policy. We may
+          change this Privacy Policy from time to time with or without notice to you. By accessing the Services after we
+          make any such changes to this Privacy Policy, you are deemed to have accepted such changes. Please be aware
+          that, to the extent permitted by applicable law, our use of the information collected is governed by the
+          Privacy Policy in effect at the time we collect the information. Please refer back to this Privacy Policy on a
+          regular basis.
+        </p>
 
-            </div>
-        </Layout>
-    )
-}
+        <p className="privacy-underline privacy-bold">CHANGES TO THIS PRIVACY POLICY</p>
+        <p>
+          If you have questions about this Privacy Policy, please e-mail us at{' '}
+          <a href="mailto:privacy@estuary.dev">privacy@estuary.dev</a> with “Privacy Policy” in the subject line.
+        </p>
+      </div>
+    </Layout>
+  );
+};
 
-export default PrivacyPolicy
+export default PrivacyPolicy;

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,97 +1,347 @@
-import * as React from "react"
-import Layout from "../components/layout"
+import * as React from 'react';
+import Layout from '../components/layout';
+import Seo from '../components/seo';
+
+export const Head = () => <Seo title="Terms of Service" />;
 
 const Terms = () => {
-    return(
-        <Layout headerTheme="light">
-            <div className="terms-root">
-                <h4>Terms of Service</h4>
-                <h6 className="terms-last-updated">Last updated January 20th, 2022</h6>
+  return (
+    <Layout headerTheme="light">
+      <div className="terms-root">
+        <h4>Terms of Service</h4>
+        <h6 className="terms-last-updated">Last updated January 20th, 2022</h6>
 
-                <p>These terms of use (the “<span className="privacy-underline">Terms of Use</span>”) are a legal agreement between you and Estuary Technologies, Inc. (“<span className="privacy-underline">Estuary</span>,” “<span className="privacy-underline">we</span>,” “<span className="privacy-underline">us</span>,” or “<span className="privacy-underline">our</span>). These Terms of Use specify the terms under which you may access and use the website located at <a href="https://www.estuary.dev/">https://www.estuary.dev/</a> (the “<span className="privacy-underline">Website</span>). Please note that we offer additional products and services, which are provided pursuant to a separate manually or digitally-executed agreement.</p>
-            
-                <p>By accessing or using our Website, or otherwise manifesting your assent to these Terms of Use, you acknowledge that you have read, understood, and agree to be legally bound by these Terms of Use and our Privacy Policy, which is hereby incorporated by reference (collectively, this “<span className="privacy-underline">Agreement</span>). If you do not agree to any of these terms, then please do not use the Website.</p>
+        <p>
+          These terms of use (the “<span className="privacy-underline">Terms of Use</span>”) are a legal agreement
+          between you and Estuary Technologies, Inc. (“<span className="privacy-underline">Estuary</span>,” “
+          <span className="privacy-underline">we</span>,” “<span className="privacy-underline">us</span>,” or “
+          <span className="privacy-underline">our</span>). These Terms of Use specify the terms under which you may
+          access and use the website located at <a href="https://www.estuary.dev/">https://www.estuary.dev/</a> (the “
+          <span className="privacy-underline">Website</span>). Please note that we offer additional products and
+          services, which are provided pursuant to a separate manually or digitally-executed agreement.
+        </p>
 
-                <p>By logging into our site, using a partner, you are also agreeing to their terms.  For information on how Google helps users share their data safely, see their information <a href="https://support.google.com/accounts/answer/10130420?hl=en">here</a>.</p>
+        <p>
+          By accessing or using our Website, or otherwise manifesting your assent to these Terms of Use, you acknowledge
+          that you have read, understood, and agree to be legally bound by these Terms of Use and our Privacy Policy,
+          which is hereby incorporated by reference (collectively, this “
+          <span className="privacy-underline">Agreement</span>). If you do not agree to any of these terms, then please
+          do not use the Website.
+        </p>
 
-                <p className="privacy-bold">THE SECTIONS BELOW TITLED “BINDING ARBITRATION” AND “CLASS ACTION WAIVER” CONTAIN A BINDING ARBITRATION AGREEMENT AND CLASS ACTION WAIVER. THEY AFFECT YOUR LEGAL RIGHTS. PLEASE READ THEM.</p>
-            
-                <p>If you accept or agree to this Agreement on behalf of a company or other legal entity, you represent and warrant that you have the authority to bind that company or other legal entity to the Agreement and, in such event, “<span className="privacy-underline">you</span>” and “<span className="privacy-underline">your</span>” will refer and apply to that company or other legal entity, and any employees, contractors, or agents authorized by you to access and use the Products pursuant to the terms of this Agreement (“<span className="privacy-underline">Authorized Users</span>”).</p>
-            
-                <p>Capitalized terms not defined in these Terms of Use shall have the meaning set forth in our Privacy Policy.</p>
+        <p>
+          By logging into our site, using a partner, you are also agreeing to their terms. For information on how Google
+          helps users share their data safely, see their information{' '}
+          <a href="https://support.google.com/accounts/answer/10130420?hl=en">here</a>.
+        </p>
 
-                <p>1. <span className="privacy-bold privacy-underline">INTELLECTUAL PROPERTY</span></p>
-                <p>The Website contains material, such as software, text, graphics, images, sound recordings, and other material provided by or on behalf of Estuary or its licensors (collectively referred to as the "<span className="privacy-underline">Content</span>”). The Content may be owned by us or third parties. The Content is protected under both United States and foreign laws. Unauthorized use of the Content may violate copyright, trademark, and other laws.</p>
-                <p>You may view all Content for your own personal, non-commercial use, and no other use is permitted without the prior written consent of Estuary. Estuary and its licensors retain all right, title, and interest, including all intellectual property rights, in and to the Content. You must retain all copyright and other proprietary notices contained in the original Content. You may not sell, transfer, assign, license, sublicense, or modify the Content or reproduce, display, publicly perform, make a derivative version of, distribute, or otherwise use the Content in any way for any public or commercial purpose. We reserve the right to remove Content from our Website at any time for any reason without any notice to you.</p>
-                <p>If you violate any part of this Agreement, your permission to access the Content and the Website automatically terminates and you must immediately destroy any copies you have made of the Content.</p>
+        <p className="privacy-bold">
+          THE SECTIONS BELOW TITLED “BINDING ARBITRATION” AND “CLASS ACTION WAIVER” CONTAIN A BINDING ARBITRATION
+          AGREEMENT AND CLASS ACTION WAIVER. THEY AFFECT YOUR LEGAL RIGHTS. PLEASE READ THEM.
+        </p>
 
-                <p>The trademarks, service marks, and logos of Estuary (the “<span className="privacy-underline">Estuary Trademarks</span>”) used and displayed on the Website is owned by Estuary. Other company, product, and service names located on the Website may be trademarks or service marks owned by others (the “<span className="privacy-underline">Third-Party Trademarks</span>,” and, collectively with Estuary Trademarks, the “<span className="privacy-underline">Trademarks</span>). Nothing on the Website should be construed as granting, by implication, estoppel, or otherwise, any license or right to use the Trademarks, without our prior written permission specific for each such use. Use of the Trademarks as part of a link to or from any site is prohibited unless establishment of such a link is approved in advance by us in writing. All goodwill generated from the use of Estuary Trademarks inures to our benefit.</p>
-                <p>Elements of the Website is protected by trade dress, trademark, unfair competition, and other state and federal laws and may not be copied or imitated in whole or in part, by any means, including, but not limited to, the use of framing or mirrors. None of the Content may be retransmitted without our express, written consent for each and every instance.</p>
+        <p>
+          If you accept or agree to this Agreement on behalf of a company or other legal entity, you represent and
+          warrant that you have the authority to bind that company or other legal entity to the Agreement and, in such
+          event, “<span className="privacy-underline">you</span>” and “<span className="privacy-underline">your</span>”
+          will refer and apply to that company or other legal entity, and any employees, contractors, or agents
+          authorized by you to access and use the Products pursuant to the terms of this Agreement (“
+          <span className="privacy-underline">Authorized Users</span>”).
+        </p>
 
+        <p>
+          Capitalized terms not defined in these Terms of Use shall have the meaning set forth in our Privacy Policy.
+        </p>
 
-                <p>2. <span className="privacy-bold privacy-underline">COMMUNITY GUIDELINES</span></p>
-                <p>Estuary’s community, like any community, functions best when its users follow a few simple rules. By accessing the Website, you agree to comply with these community guidelines (the “<span className="privacy-underline">Community Guidelines</span>”) and that:</p>
-                <ul>
-                    <li>You will comply with all applicable laws in your use of the Website and will not use the Website for any unlawful purpose;</li>
-                    <li>You will not access or use the Website to collect any market research for a competing business;</li>
-                    <li>You will not impersonate any person or entity or falsely state or otherwise misrepresent your affiliation with a person or entity;</li>
-                    <li>You will not interfere with or attempt to interrupt the proper operation of the Website through the use of any virus, device, information collection or transmission mechanism, software or routine, or access or attempt to gain access to any Content (as defined below), data, files, or passwords related to the Website through hacking, password or data mining, or any other means;</li>
-                    <li>You will not decompile, reverse engineer, or disassemble any software or other products or processes accessible through the Website;</li>
-                    <li>You will not cover, obscure, block, or in any way interfere with any advertisements and/or safety features on the Website;</li>
-                    <li>You will not circumvent, remove, alter, deactivate, degrade, or thwart any of the Content protections in the Website;</li>
-                    <li>You will not use any robot, spider, scraper, or other automated means to access the Website for any purpose without our express, written permission; <span className="privacy-underline">provided, however</span>, that we may grant the operators of public search engines permission to use spiders to copy materials from the public portions of the Website for the sole purpose of, and solely to the extent necessary for, creating publicly-available searchable indices of the materials, but not caches or archives of such materials; and</li>
-                    <li>You will not take any action that imposes or may impose (in our sole discretion) an unreasonable or disproportionately large load on our technical infrastructure.</li>
-                </ul>
-                <p>If you find something that violates our Community Guidelines, please let us know, and we’ll review it.</p>
+        <p>
+          1. <span className="privacy-bold privacy-underline">INTELLECTUAL PROPERTY</span>
+        </p>
+        <p>
+          The Website contains material, such as software, text, graphics, images, sound recordings, and other material
+          provided by or on behalf of Estuary or its licensors (collectively referred to as the "
+          <span className="privacy-underline">Content</span>”). The Content may be owned by us or third parties. The
+          Content is protected under both United States and foreign laws. Unauthorized use of the Content may violate
+          copyright, trademark, and other laws.
+        </p>
+        <p>
+          You may view all Content for your own personal, non-commercial use, and no other use is permitted without the
+          prior written consent of Estuary. Estuary and its licensors retain all right, title, and interest, including
+          all intellectual property rights, in and to the Content. You must retain all copyright and other proprietary
+          notices contained in the original Content. You may not sell, transfer, assign, license, sublicense, or modify
+          the Content or reproduce, display, publicly perform, make a derivative version of, distribute, or otherwise
+          use the Content in any way for any public or commercial purpose. We reserve the right to remove Content from
+          our Website at any time for any reason without any notice to you.
+        </p>
+        <p>
+          If you violate any part of this Agreement, your permission to access the Content and the Website automatically
+          terminates and you must immediately destroy any copies you have made of the Content.
+        </p>
 
-                <p>3. <span className="privacy-bold privacy-underline">COMMUNICATIONS WITH US</span></p>
-                <p>Although we encourage you to e-mail us, we do not want you to, and you should not, e-mail us any content that contains confidential information. With respect to all e-mails and communications you send to us, including, but not limited to, feedback, questions, comments, suggestions, and the like, we shall be free to use any ideas, concepts, know-how, or techniques contained in your communications for any purpose whatsoever, including but not limited to, the development, production, and marketing of products and services that incorporate such information without compensation or attribution to you.</p>
+        <p>
+          The trademarks, service marks, and logos of Estuary (the “
+          <span className="privacy-underline">Estuary Trademarks</span>”) used and displayed on the Website is owned by
+          Estuary. Other company, product, and service names located on the Website may be trademarks or service marks
+          owned by others (the “<span className="privacy-underline">Third-Party Trademarks</span>,” and, collectively
+          with Estuary Trademarks, the “<span className="privacy-underline">Trademarks</span>). Nothing on the Website
+          should be construed as granting, by implication, estoppel, or otherwise, any license or right to use the
+          Trademarks, without our prior written permission specific for each such use. Use of the Trademarks as part of
+          a link to or from any site is prohibited unless establishment of such a link is approved in advance by us in
+          writing. All goodwill generated from the use of Estuary Trademarks inures to our benefit.
+        </p>
+        <p>
+          Elements of the Website is protected by trade dress, trademark, unfair competition, and other state and
+          federal laws and may not be copied or imitated in whole or in part, by any means, including, but not limited
+          to, the use of framing or mirrors. None of the Content may be retransmitted without our express, written
+          consent for each and every instance.
+        </p>
 
-                <p>4. <span className="privacy-bold privacy-underline">NO WARRANTIES; LIMITATION OF LIABILITY</span></p>
-                <p>THE WEBSITE AND THE CONTENT ARE PROVIDED “AS IS” AND “AS AVAILABLE” WITHOUT ANY WARRANTIES OF ANY KIND, INCLUDING THAT THE WEBSITE OR CONTENT WILL OPERATE ERROR-FREE OR THAT THE WEBSITE, ITS SERVERS, OR THE CONTENT ARE FREE OF COMPUTER VIRUSES OR SIMILAR CONTAMINATION OR DESTRUCTIVE FEATURES.</p>
-                <p>WE DISCLAIM ALL WARRANTIES, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, MERCHANTABILITY, NON-INFRINGEMENT OF THIRD PARTIES’ RIGHTS, AND FITNESS FOR PARTICULAR PURPOSE AND ANY WARRANTIES ARISING FROM A COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE.</p>
-                <p>THE WEBSITE MAY CONTAIN TECHNICAL INACCURACIES OR TYPOGRAPHICAL ERRORS OR OMISSIONS. UNLESS REQUIRED BY APPLICABLE LAWS, WE ARE NOT RESPONSIBLE FOR ANY SUCH TYPOGRAPHICAL OR TECHNICAL ERRORS LISTED ON THE WEBSITE. WE RESERVE THE RIGHT TO MAKE CHANGES, CORRECTIONS, AND/OR IMPROVEMENTS TO THE WEBSITE AND/OR ADD OR REMOVE CONTENT AT ANY TIME WITHOUT NOTICE.</p>
-                <p>IN CONNECTION WITH ANY WARRANTY, CONTRACT, OR COMMON LAW TORT CLAIMS: (I) WE AND OUR LICENSORS SHALL NOT BE LIABLE FOR ANY INCIDENTAL OR CONSEQUENTIAL DAMAGES, LOST PROFITS, OR DAMAGES RESULTING FROM LOST DATA OR BUSINESS INTERRUPTION RESULTING FROM THE USE OR INABILITY TO ACCESS AND USE THE WEBSITE OR THE CONTENT, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES; AND (II) ANY DIRECT DAMAGES THAT YOU MAY SUFFER AS A RESULT OF YOUR USE OF THE WEBSITE OR THE CONTENT SHALL BE LIMITED TO FIFTY US DOLLARS ($50).</p>
-                <p>SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF CERTAIN WARRANTIES. THEREFORE, SOME OF THE ABOVE LIMITATIONS ON WARRANTIES IN THIS SECTION MAY NOT APPLY TO YOU.</p>
-                <p>NOTHING IN THESE TERMS OF USE SHALL AFFECT ANY NON-WAIVABLE STATUTORY RIGHTS THAT APPLY TO YOU.</p>
+        <p>
+          2. <span className="privacy-bold privacy-underline">COMMUNITY GUIDELINES</span>
+        </p>
+        <p>
+          Estuary’s community, like any community, functions best when its users follow a few simple rules. By accessing
+          the Website, you agree to comply with these community guidelines (the “
+          <span className="privacy-underline">Community Guidelines</span>”) and that:
+        </p>
+        <ul>
+          <li>
+            You will comply with all applicable laws in your use of the Website and will not use the Website for any
+            unlawful purpose;
+          </li>
+          <li>You will not access or use the Website to collect any market research for a competing business;</li>
+          <li>
+            You will not impersonate any person or entity or falsely state or otherwise misrepresent your affiliation
+            with a person or entity;
+          </li>
+          <li>
+            You will not interfere with or attempt to interrupt the proper operation of the Website through the use of
+            any virus, device, information collection or transmission mechanism, software or routine, or access or
+            attempt to gain access to any Content (as defined below), data, files, or passwords related to the Website
+            through hacking, password or data mining, or any other means;
+          </li>
+          <li>
+            You will not decompile, reverse engineer, or disassemble any software or other products or processes
+            accessible through the Website;
+          </li>
+          <li>
+            You will not cover, obscure, block, or in any way interfere with any advertisements and/or safety features
+            on the Website;
+          </li>
+          <li>
+            You will not circumvent, remove, alter, deactivate, degrade, or thwart any of the Content protections in the
+            Website;
+          </li>
+          <li>
+            You will not use any robot, spider, scraper, or other automated means to access the Website for any purpose
+            without our express, written permission; <span className="privacy-underline">provided, however</span>, that
+            we may grant the operators of public search engines permission to use spiders to copy materials from the
+            public portions of the Website for the sole purpose of, and solely to the extent necessary for, creating
+            publicly-available searchable indices of the materials, but not caches or archives of such materials; and
+          </li>
+          <li>
+            You will not take any action that imposes or may impose (in our sole discretion) an unreasonable or
+            disproportionately large load on our technical infrastructure.
+          </li>
+        </ul>
+        <p>If you find something that violates our Community Guidelines, please let us know, and we’ll review it.</p>
 
-                <p>5. <span className="privacy-bold privacy-underline">EXTERNAL SITES</span></p>
-                <p>The Website may contain links to third-party websites (“<span className="privacy-underline">External Sites</span>”). These links are provided solely as a convenience to you and not as an endorsement by us of the content on such External Sites. The content of such External Sites is developed and provided by others. You should contact the site administrator or webmaster for those External Sites if you have any concerns regarding such links or any content located on such External Sites. We are not responsible for the content of any linked External Sites and do not make any representations regarding the content or accuracy of materials on such External Sites. You should take precautions when downloading files from all websites to protect your computer from viruses and other destructive programs. If you decide to access linked External Sites, you do so at your own risk.</p>
+        <p>
+          3. <span className="privacy-bold privacy-underline">COMMUNICATIONS WITH US</span>
+        </p>
+        <p>
+          Although we encourage you to e-mail us, we do not want you to, and you should not, e-mail us any content that
+          contains confidential information. With respect to all e-mails and communications you send to us, including,
+          but not limited to, feedback, questions, comments, suggestions, and the like, we shall be free to use any
+          ideas, concepts, know-how, or techniques contained in your communications for any purpose whatsoever,
+          including but not limited to, the development, production, and marketing of products and services that
+          incorporate such information without compensation or attribution to you.
+        </p>
 
-                <p>6. <span className="privacy-bold privacy-underline">INDEMNIFICATION</span></p>
-                <p>You agree to defend, indemnify, and hold us and our officers, directors, employees, agents, successors, licensees, licensors, and assigns harmless from and against any damages, liabilities, losses, expenses, claims, actions, and/or demands, including, without limitation, reasonable legal and accounting fees, arising or resulting from: (i) your breach of this Agreement; (ii) your misuse of the Content or the Website; and/or (iii) your violation of any third-party rights, including without limitation any copyright, trademark, property, publicity, or privacy right. We shall provide notice to you of any such claim, suit, or proceeding and shall assist you, at your expense, in defending any such claim, suit, or proceeding. We reserve the right to assume the exclusive defense and control (at your expense) of any matter that is subject to indemnification under this section. In such case, you agree to cooperate with any reasonable requests assisting our defense of such matter.</p>
+        <p>
+          4. <span className="privacy-bold privacy-underline">NO WARRANTIES; LIMITATION OF LIABILITY</span>
+        </p>
+        <p>
+          THE WEBSITE AND THE CONTENT ARE PROVIDED “AS IS” AND “AS AVAILABLE” WITHOUT ANY WARRANTIES OF ANY KIND,
+          INCLUDING THAT THE WEBSITE OR CONTENT WILL OPERATE ERROR-FREE OR THAT THE WEBSITE, ITS SERVERS, OR THE CONTENT
+          ARE FREE OF COMPUTER VIRUSES OR SIMILAR CONTAMINATION OR DESTRUCTIVE FEATURES.
+        </p>
+        <p>
+          WE DISCLAIM ALL WARRANTIES, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, MERCHANTABILITY,
+          NON-INFRINGEMENT OF THIRD PARTIES’ RIGHTS, AND FITNESS FOR PARTICULAR PURPOSE AND ANY WARRANTIES ARISING FROM
+          A COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE.
+        </p>
+        <p>
+          THE WEBSITE MAY CONTAIN TECHNICAL INACCURACIES OR TYPOGRAPHICAL ERRORS OR OMISSIONS. UNLESS REQUIRED BY
+          APPLICABLE LAWS, WE ARE NOT RESPONSIBLE FOR ANY SUCH TYPOGRAPHICAL OR TECHNICAL ERRORS LISTED ON THE WEBSITE.
+          WE RESERVE THE RIGHT TO MAKE CHANGES, CORRECTIONS, AND/OR IMPROVEMENTS TO THE WEBSITE AND/OR ADD OR REMOVE
+          CONTENT AT ANY TIME WITHOUT NOTICE.
+        </p>
+        <p>
+          IN CONNECTION WITH ANY WARRANTY, CONTRACT, OR COMMON LAW TORT CLAIMS: (I) WE AND OUR LICENSORS SHALL NOT BE
+          LIABLE FOR ANY INCIDENTAL OR CONSEQUENTIAL DAMAGES, LOST PROFITS, OR DAMAGES RESULTING FROM LOST DATA OR
+          BUSINESS INTERRUPTION RESULTING FROM THE USE OR INABILITY TO ACCESS AND USE THE WEBSITE OR THE CONTENT, EVEN
+          IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES; AND (II) ANY DIRECT DAMAGES THAT YOU MAY SUFFER AS
+          A RESULT OF YOUR USE OF THE WEBSITE OR THE CONTENT SHALL BE LIMITED TO FIFTY US DOLLARS ($50).
+        </p>
+        <p>
+          SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF CERTAIN WARRANTIES. THEREFORE, SOME OF THE ABOVE LIMITATIONS
+          ON WARRANTIES IN THIS SECTION MAY NOT APPLY TO YOU.
+        </p>
+        <p>NOTHING IN THESE TERMS OF USE SHALL AFFECT ANY NON-WAIVABLE STATUTORY RIGHTS THAT APPLY TO YOU.</p>
 
-                <p>7. <span className="privacy-bold privacy-underline">COMPLIANCE WITH APPLICABLE LAWS</span></p>
-                <p>The Website is based in the United States. We make no claims concerning whether the Content may be downloaded, viewed, or be appropriate for use outside of the United States. If you access the Website or the Content from outside of the United States, you do so at your own risk. Whether inside or outside of the United States, you are solely responsible for ensuring compliance with the laws of your specific jurisdiction.</p>
+        <p>
+          5. <span className="privacy-bold privacy-underline">EXTERNAL SITES</span>
+        </p>
+        <p>
+          The Website may contain links to third-party websites (“
+          <span className="privacy-underline">External Sites</span>”). These links are provided solely as a convenience
+          to you and not as an endorsement by us of the content on such External Sites. The content of such External
+          Sites is developed and provided by others. You should contact the site administrator or webmaster for those
+          External Sites if you have any concerns regarding such links or any content located on such External Sites. We
+          are not responsible for the content of any linked External Sites and do not make any representations regarding
+          the content or accuracy of materials on such External Sites. You should take precautions when downloading
+          files from all websites to protect your computer from viruses and other destructive programs. If you decide to
+          access linked External Sites, you do so at your own risk.
+        </p>
 
-                <p>8. <span className="privacy-bold privacy-underline">CHANGES TO THE AGREEMENT</span></p>
-                <p>These Terms of Use are effective as of the last updated date stated at the top. We may change these Terms of Use from time to time with or without notice to you. Any such changes will be posted on the Website. By accessing the Website after we make any such changes to these Terms of Use, you are deemed to have accepted such changes. Please refer back to these Terms of Use on a regular basis.</p>
+        <p>
+          6. <span className="privacy-bold privacy-underline">INDEMNIFICATION</span>
+        </p>
+        <p>
+          You agree to defend, indemnify, and hold us and our officers, directors, employees, agents, successors,
+          licensees, licensors, and assigns harmless from and against any damages, liabilities, losses, expenses,
+          claims, actions, and/or demands, including, without limitation, reasonable legal and accounting fees, arising
+          or resulting from: (i) your breach of this Agreement; (ii) your misuse of the Content or the Website; and/or
+          (iii) your violation of any third-party rights, including without limitation any copyright, trademark,
+          property, publicity, or privacy right. We shall provide notice to you of any such claim, suit, or proceeding
+          and shall assist you, at your expense, in defending any such claim, suit, or proceeding. We reserve the right
+          to assume the exclusive defense and control (at your expense) of any matter that is subject to indemnification
+          under this section. In such case, you agree to cooperate with any reasonable requests assisting our defense of
+          such matter.
+        </p>
 
-                <p>9. <span className="privacy-bold privacy-underline">TERMINATION OF THE AGREEMENT</span></p>
-                <p>We reserve the right, in our sole discretion, to restrict, suspend, or terminate this Agreement and the Website, and your access to all or any part of the Website, at any time and for any reason without prior notice or liability. <span className="privacy-underline">Sections 3-15</span> shall survive the termination of this Agreement.</p>
+        <p>
+          7. <span className="privacy-bold privacy-underline">COMPLIANCE WITH APPLICABLE LAWS</span>
+        </p>
+        <p>
+          The Website is based in the United States. We make no claims concerning whether the Content may be downloaded,
+          viewed, or be appropriate for use outside of the United States. If you access the Website or the Content from
+          outside of the United States, you do so at your own risk. Whether inside or outside of the United States, you
+          are solely responsible for ensuring compliance with the laws of your specific jurisdiction.
+        </p>
 
-                <p>10. <span className="privacy-bold privacy-underline">CONTROLLING LAW</span></p>
-                <p>This Agreement and any action related thereto will be governed by the laws of the State of New York without regard to its conflict of laws provisions.</p>
-            
-                <p>11. <span className="privacy-bold privacy-underline">BINDING ARBITRATION</span></p>
-                <p>In the event of a dispute arising between you and Estuary under or relating to these Terms of Use or the Website (each, a “<span className="privacy-underline">Dispute</span>”), such dispute will be finally and exclusively resolved by binding arbitration governed by the Federal Arbitration Act (“<span className="privacy-underline">FAA</span>). Any election to arbitrate, at any time, shall be final and binding on the other party. NEITHER PARTY SHALL HAVE THE RIGHT TO LITIGATE SUCH CLAIM IN COURT OR TO HAVE A JURY TRIAL, EXCEPT EITHER PARTY MAY BRING ITS CLAIM IN ITS LOCAL SMALL CLAIMS COURT, IF PERMITTED BY THAT SMALL CLAIMS COURT RULES AND IF WITHIN SUCH COURT’S JURISDICTION. ARBITRATION IS DIFFERENT FROM COURT, AND DISCOVERY AND APPEAL RIGHTS MAY ALSO BE LIMITED IN ARBITRATION. All disputes will be resolved before a neutral arbitrator selected jointly by you and Estuary, whose decision will be final, except for a limited right of appeal under the FAA. The arbitration shall be commenced and conducted by JAMS pursuant to its then current Comprehensive Arbitration Rules and Procedures and in accordance with the Expedited Procedures in those rules, or, where appropriate, pursuant to JAMS’ Streamlined Arbitration Rules and Procedures. All applicable JAMS’ rules and procedures are available at the JAMS website www.jamsadr.com. Each of you and Estuary will be responsible for paying any JAMS filing, administrative, and arbitrator fees in accordance with JAMS rules. Judgment on the arbitrator’s award may be entered in any court having jurisdiction. This clause shall not preclude parties from seeking provisional remedies in aid of arbitration from a court of appropriate jurisdiction. The arbitration may be conducted in person, through the submission of documents, by phone, or online. If conducted in person, the arbitration shall take place in the United States county where you reside. The parties may litigate in court to compel arbitration, to stay a proceeding pending arbitration, or to confirm, modify, vacate, or enter judgment on the award entered by the arbitrator. The parties shall cooperate in good faith in the voluntary and informal exchange of all non-privileged documents and other information (including electronically stored information) relevant to the Dispute immediately after commencement of the arbitration. As set forth in <span className="privacy-underline">Section 13</span> below, nothing in these Terms of Use will prevent us from seeking injunctive relief in any court of competent jurisdiction as necessary to protect our proprietary interests.</p>
-            
-                <p>12. <span className="privacy-bold privacy-underline">CLASS ACTION WAIVER</span></p>
-                <p>You agree that any arbitration or proceeding shall be limited to the Dispute between us and you individually. To the full extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any Dispute to be arbitrated or resolved on a class action-basis or to utilize class action procedures; and (iii) there is no right or authority for any Dispute to be brought in a purported representative capacity on behalf of the general public or any other persons. YOU AGREE THAT YOU MAY BRING CLAIMS AGAINST US ONLY IN YOUR INDIVIDUAL CAPACITY AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS OR REPRESENTATIVE PROCEEDING.</p>
-            
-                <p>13. <span className="privacy-bold privacy-underline">EQUITABLE RELIEF</span></p>
-                <p>You acknowledge and agree that in the event of a breach or threatened violation of our intellectual property rights and confidential and proprietary information by you, we will suffer irreparable harm and will therefore be entitled to injunctive relief to enforce this Agreement. We may, without waiving any other remedies under this Agreement, seek from any court having jurisdiction any interim, equitable, provisional, or injunctive relief that is necessary to protect our rights and property pending the outcome of the arbitration referenced above. All claims or disputes arising out of or in connection with this Agreement shall be heard exclusively by any of the federal or state courts of competent jurisdiction located in the State of New York.</p>
+        <p>
+          8. <span className="privacy-bold privacy-underline">CHANGES TO THE AGREEMENT</span>
+        </p>
+        <p>
+          These Terms of Use are effective as of the last updated date stated at the top. We may change these Terms of
+          Use from time to time with or without notice to you. Any such changes will be posted on the Website. By
+          accessing the Website after we make any such changes to these Terms of Use, you are deemed to have accepted
+          such changes. Please refer back to these Terms of Use on a regular basis.
+        </p>
 
-                <p>14. <span className="privacy-bold privacy-underline">RESTRICTIONS</span></p>
-                <p>The Website is available only to individuals aged 13 years or older. If you are 13 or older, but under the age of majority in your jurisdiction, you should review the Agreement with your parent or guardian to make sure that you and your parent or guardian understand it. If you are under the age of 13, you may use the Website only with the consent of your parent or guardian. We reserve the right, in our sole and absolute discretion, to deny you access to the Website, or any portion of the Website, without notice and without reason.</p>
+        <p>
+          9. <span className="privacy-bold privacy-underline">TERMINATION OF THE AGREEMENT</span>
+        </p>
+        <p>
+          We reserve the right, in our sole discretion, to restrict, suspend, or terminate this Agreement and the
+          Website, and your access to all or any part of the Website, at any time and for any reason without prior
+          notice or liability. <span className="privacy-underline">Sections 3-15</span> shall survive the termination of
+          this Agreement.
+        </p>
 
-                <p>15. <span className="privacy-bold privacy-underline">MISCELLANEOUS</span></p>
-                <p>Our failure to act on or enforce any provision of the Agreement shall not be construed as a waiver of that provision or any other provision in this Agreement. No waiver shall be effective against us unless made in writing, and no such waiver shall be construed as a waiver in any other or subsequent instance. Except as expressly agreed by us and you in writing, this Agreement constitutes the entire Agreement between you and us with respect to the subject matter, and supersedes all previous or contemporaneous agreements, whether written or oral, between the parties with respect to the subject matter. The section headings are provided merely for convenience and shall not be given any legal import. This Agreement will inure to the benefit of our successors, assigns, licensees, and sublicensees.</p>
+        <p>
+          10. <span className="privacy-bold privacy-underline">CONTROLLING LAW</span>
+        </p>
+        <p>
+          This Agreement and any action related thereto will be governed by the laws of the State of New York without
+          regard to its conflict of laws provisions.
+        </p>
 
-            </div>
-        </Layout>
-    )
-}
+        <p>
+          11. <span className="privacy-bold privacy-underline">BINDING ARBITRATION</span>
+        </p>
+        <p>
+          In the event of a dispute arising between you and Estuary under or relating to these Terms of Use or the
+          Website (each, a “<span className="privacy-underline">Dispute</span>”), such dispute will be finally and
+          exclusively resolved by binding arbitration governed by the Federal Arbitration Act (“
+          <span className="privacy-underline">FAA</span>). Any election to arbitrate, at any time, shall be final and
+          binding on the other party. NEITHER PARTY SHALL HAVE THE RIGHT TO LITIGATE SUCH CLAIM IN COURT OR TO HAVE A
+          JURY TRIAL, EXCEPT EITHER PARTY MAY BRING ITS CLAIM IN ITS LOCAL SMALL CLAIMS COURT, IF PERMITTED BY THAT
+          SMALL CLAIMS COURT RULES AND IF WITHIN SUCH COURT’S JURISDICTION. ARBITRATION IS DIFFERENT FROM COURT, AND
+          DISCOVERY AND APPEAL RIGHTS MAY ALSO BE LIMITED IN ARBITRATION. All disputes will be resolved before a neutral
+          arbitrator selected jointly by you and Estuary, whose decision will be final, except for a limited right of
+          appeal under the FAA. The arbitration shall be commenced and conducted by JAMS pursuant to its then current
+          Comprehensive Arbitration Rules and Procedures and in accordance with the Expedited Procedures in those rules,
+          or, where appropriate, pursuant to JAMS’ Streamlined Arbitration Rules and Procedures. All applicable JAMS’
+          rules and procedures are available at the JAMS website www.jamsadr.com. Each of you and Estuary will be
+          responsible for paying any JAMS filing, administrative, and arbitrator fees in accordance with JAMS rules.
+          Judgment on the arbitrator’s award may be entered in any court having jurisdiction. This clause shall not
+          preclude parties from seeking provisional remedies in aid of arbitration from a court of appropriate
+          jurisdiction. The arbitration may be conducted in person, through the submission of documents, by phone, or
+          online. If conducted in person, the arbitration shall take place in the United States county where you reside.
+          The parties may litigate in court to compel arbitration, to stay a proceeding pending arbitration, or to
+          confirm, modify, vacate, or enter judgment on the award entered by the arbitrator. The parties shall cooperate
+          in good faith in the voluntary and informal exchange of all non-privileged documents and other information
+          (including electronically stored information) relevant to the Dispute immediately after commencement of the
+          arbitration. As set forth in <span className="privacy-underline">Section 13</span> below, nothing in these
+          Terms of Use will prevent us from seeking injunctive relief in any court of competent jurisdiction as
+          necessary to protect our proprietary interests.
+        </p>
 
+        <p>
+          12. <span className="privacy-bold privacy-underline">CLASS ACTION WAIVER</span>
+        </p>
+        <p>
+          You agree that any arbitration or proceeding shall be limited to the Dispute between us and you individually.
+          To the full extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii)
+          there is no right or authority for any Dispute to be arbitrated or resolved on a class action-basis or to
+          utilize class action procedures; and (iii) there is no right or authority for any Dispute to be brought in a
+          purported representative capacity on behalf of the general public or any other persons. YOU AGREE THAT YOU MAY
+          BRING CLAIMS AGAINST US ONLY IN YOUR INDIVIDUAL CAPACITY AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY
+          PURPORTED CLASS OR REPRESENTATIVE PROCEEDING.
+        </p>
+
+        <p>
+          13. <span className="privacy-bold privacy-underline">EQUITABLE RELIEF</span>
+        </p>
+        <p>
+          You acknowledge and agree that in the event of a breach or threatened violation of our intellectual property
+          rights and confidential and proprietary information by you, we will suffer irreparable harm and will therefore
+          be entitled to injunctive relief to enforce this Agreement. We may, without waiving any other remedies under
+          this Agreement, seek from any court having jurisdiction any interim, equitable, provisional, or injunctive
+          relief that is necessary to protect our rights and property pending the outcome of the arbitration referenced
+          above. All claims or disputes arising out of or in connection with this Agreement shall be heard exclusively
+          by any of the federal or state courts of competent jurisdiction located in the State of New York.
+        </p>
+
+        <p>
+          14. <span className="privacy-bold privacy-underline">RESTRICTIONS</span>
+        </p>
+        <p>
+          The Website is available only to individuals aged 13 years or older. If you are 13 or older, but under the age
+          of majority in your jurisdiction, you should review the Agreement with your parent or guardian to make sure
+          that you and your parent or guardian understand it. If you are under the age of 13, you may use the Website
+          only with the consent of your parent or guardian. We reserve the right, in our sole and absolute discretion,
+          to deny you access to the Website, or any portion of the Website, without notice and without reason.
+        </p>
+
+        <p>
+          15. <span className="privacy-bold privacy-underline">MISCELLANEOUS</span>
+        </p>
+        <p>
+          Our failure to act on or enforce any provision of the Agreement shall not be construed as a waiver of that
+          provision or any other provision in this Agreement. No waiver shall be effective against us unless made in
+          writing, and no such waiver shall be construed as a waiver in any other or subsequent instance. Except as
+          expressly agreed by us and you in writing, this Agreement constitutes the entire Agreement between you and us
+          with respect to the subject matter, and supersedes all previous or contemporaneous agreements, whether written
+          or oral, between the parties with respect to the subject matter. The section headings are provided merely for
+          convenience and shall not be given any legal import. This Agreement will inure to the benefit of our
+          successors, assigns, licensees, and sublicensees.
+        </p>
+      </div>
+    </Layout>
+  );
+};
 
 export default Terms;

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -221,7 +221,7 @@ export const Step7 = ({ activePage }) => {
   );
 };
 
-export const Head = () => <Seo title="Walkthrough" />;
+export const Head = () => <Seo title="Why" />;
 
 const WhyEstuary = () => {
   const [activePage, setActivePage] = React.useState(0);

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -221,7 +221,7 @@ export const Step7 = ({ activePage }) => {
   );
 };
 
-export const Head = () => <Seo title="Estuary Walkthrough" />;
+export const Head = () => <Seo title="Walkthrough" />;
 
 const WhyEstuary = () => {
   const [activePage, setActivePage] = React.useState(0);

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -1,472 +1,330 @@
-import * as React from "react"
-import ColoredLogo from "../svgs/colored-logo.svg"
-import { OutboundLink } from "../components/OutboundLink"
-import { Link } from "gatsby"
-import { StaticImage } from "gatsby-plugin-image"
+import * as React from 'react';
+import ColoredLogo from '../svgs/colored-logo.svg';
+import { OutboundLink } from '../components/OutboundLink';
+import { Link } from 'gatsby';
+import { StaticImage } from 'gatsby-plugin-image';
 
-import { currencyFormatter, calculatePrice } from "../layouts/Pricing/utils"
+import { currencyFormatter, calculatePrice } from '../layouts/Pricing/utils';
+import Seo from '../components/seo';
 
 export const Step0 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <div className="step-heading">
-                    Estuary is your automated data streaming control center
-                </div>
-                <div className="step-subheading">
-                    <p>Move your data where, when, and how you need it…</p>
-                    <p>
-                        ...without scheduling, technical debt, or sacrificing
-                        control.
-                    </p>
-                </div>
-                <div
-                    className="steps-cta start-start"
-                    onClick={() => setState(activePage + 1)}
-                >
-                    Start Tour
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <div className="step-heading">Estuary is your automated data streaming control center</div>
+        <div className="step-subheading">
+          <p>Move your data where, when, and how you need it…</p>
+          <p>...without scheduling, technical debt, or sacrificing control.</p>
         </div>
-    )
-}
+        <div className="steps-cta start-start" onClick={() => setState(activePage + 1)}>
+          Start Tour
+        </div>
+      </div>
+    </div>
+  );
+};
 export const Step1 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step1-image.png"
-                    layout="constrained"
-                    width={950}
-                    height={597}
-                    quality={100}
-                />
-                <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip left">
-                    <div className="tooltip-heading">Connect Source</div>
-                    <div className="tooltip-description">
-                        Choose from databases, SaaS APIs, filestores, pub-sub
-                        systems, Vector DB, and more.
-                    </div>
-                    <div className="tooltip-action">
-                        Click the dot to continue
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step1-image.png"
+          layout="constrained"
+          width={950}
+          height={597}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip left">
+          <div className="tooltip-heading">Connect Source</div>
+          <div className="tooltip-description">
+            Choose from databases, SaaS APIs, filestores, pub-sub systems, Vector DB, and more.
+          </div>
+          <div className="tooltip-action">Click the dot to continue</div>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step2 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step2-image.png"
-                    layout="constrained"
-                    width={950}
-                    height={597}
-                    quality={100}
-                />
-                <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip top">
-                    <div className="tooltip-heading">Automated Schema</div>
-                    <div className="tooltip-description">
-                        Flow infers and automatically evolves the best schemas
-                        for your source data tables, streams, or API objects.
-                    </div>
-                    <div className="tooltip-description">
-                        You're free to make changes, but you'll rarely want to.
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step2-image.png"
+          layout="constrained"
+          width={950}
+          height={597}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip top">
+          <div className="tooltip-heading">Automated Schema</div>
+          <div className="tooltip-description">
+            Flow infers and automatically evolves the best schemas for your source data tables, streams, or API objects.
+          </div>
+          <div className="tooltip-description">You're free to make changes, but you'll rarely want to.</div>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step3 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step3-image.png"
-                    layout="constrained"
-                    width={950}
-                    height={597}
-                    quality={100}
-                />
-                 <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip left">
-                    <div className="tooltip-heading">Success!</div>
-                    <div className="tooltip-description">
-                        You'll never have to connect that data source again!
-                    </div>
-                    <div className="tooltip-description">
-                        Whether you need 1-millisecond or 1-hour syncs, building
-                        pipelines on our event-driven architecture gives you:
-                    </div>
-                    <ul className="tooltip-list">
-                        <li>
-                            Greater <b>cost efficiency</b> since only
-                            incremental data is processed.
-                        </li>
-                        <li>
-                            <b>Boundless horizontal scalability.</b>
-                        </li>
-                        <li>
-                            <b>Resilient and fault tolerant</b> pipelines.
-                        </li>
-                    </ul>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step3-image.png"
+          layout="constrained"
+          width={950}
+          height={597}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip left">
+          <div className="tooltip-heading">Success!</div>
+          <div className="tooltip-description">You'll never have to connect that data source again!</div>
+          <div className="tooltip-description">
+            Whether you need 1-millisecond or 1-hour syncs, building pipelines on our event-driven architecture gives
+            you:
+          </div>
+          <ul className="tooltip-list">
+            <li>
+              Greater <b>cost efficiency</b> since only incremental data is processed.
+            </li>
+            <li>
+              <b>Boundless horizontal scalability.</b>
+            </li>
+            <li>
+              <b>Resilient and fault tolerant</b> pipelines.
+            </li>
+          </ul>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step4 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step4-image.png"
-                    layout="constrained"
-                    width={950}
-                    height={597}
-                    quality={100}
-                />
-                <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip left">
-                    <div className="tooltip-heading">
-                        Your Data 'Collections'
-                    </div>
-                    <div className="tooltip-description">
-                        Flow stores data from your captures as collections:
-                        groups of cleaned, de-duped, and validated, JSON files
-                        in your cloud storage. Both your real-time and
-                        historical data live here.
-                    </div>
-                    <div className="tooltip-description">
-                        You can stream these collections to destinations with
-                        sub-second latency, or add an in-flight transformation
-                        step first.
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step4-image.png"
+          layout="constrained"
+          width={950}
+          height={597}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip left">
+          <div className="tooltip-heading">Your Data 'Collections'</div>
+          <div className="tooltip-description">
+            Flow stores data from your captures as collections: groups of cleaned, de-duped, and validated, JSON files
+            in your cloud storage. Both your real-time and historical data live here.
+          </div>
+          <div className="tooltip-description">
+            You can stream these collections to destinations with sub-second latency, or add an in-flight transformation
+            step first.
+          </div>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step5 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step5-image.png"
-                    layout="constrained"
-                    width={956}
-                    height={521}
-                    quality={100}
-                />
-                <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip right">
-                    <div className="tooltip-heading">Transform your data</div>
-                    <div className="tooltip-description">
-                        Use SQL or TypeScript to apply stateful transforms
-                        in-flight, or to join your collections. Send only the
-                        data you need to your warehouse.
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step5-image.png"
+          layout="constrained"
+          width={956}
+          height={521}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip right">
+          <div className="tooltip-heading">Transform your data</div>
+          <div className="tooltip-description">
+            Use SQL or TypeScript to apply stateful transforms in-flight, or to join your collections. Send only the
+            data you need to your warehouse.
+          </div>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step6 = ({ activePage, setState }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <StaticImage
-                    placeholder="none"
-                    alt="Data Engineering Podcast"
-                    loading="lazy"
-                    src="../images/flow-images/step6-image.png"
-                    layout="constrained"
-                    width={949}
-                    height={597}
-                    quality={100}
-                />
-                <div
-                    className="zoom-in-out-circle"
-                    onClick={() => setState(activePage + 1)}
-                ></div>
-                <div className="button-tooltip right">
-                    <div className="tooltip-heading">Materialize Data</div>
-                    <div className="tooltip-description">
-                        Stream collections to your destinations with sub-second
-                        latency and exactly-once processing guarantees.
-                    </div>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <StaticImage
+          placeholder="none"
+          alt="Data Engineering Podcast"
+          loading="lazy"
+          src="../images/flow-images/step6-image.png"
+          layout="constrained"
+          width={949}
+          height={597}
+          quality={100}
+        />
+        <div className="zoom-in-out-circle" onClick={() => setState(activePage + 1)}></div>
+        <div className="button-tooltip right">
+          <div className="tooltip-heading">Materialize Data</div>
+          <div className="tooltip-description">
+            Stream collections to your destinations with sub-second latency and exactly-once processing guarantees.
+          </div>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
 export const Step7 = ({ activePage }) => {
-    return (
-        <div className={`step-${activePage}`}>
-            <div className="step-content">
-                <div className="step-heading">Predictable Pricing</div>
-                <ul>
-                    <li><b>{currencyFormatter.format(calculatePrice(1,0).estuary)}</b>/GB</li>
-                    <li><b>{currencyFormatter.format(calculatePrice(0,1).estuary)}</b>/task month</li>
-                    <li>Free for up to two tasks and 10 GB/month</li>
-                </ul>
-                <div className="step-ctas">
-                    <OutboundLink
-                        target="_blank"
-                        href="https://dashboard.estuary.dev/register"
-                        className="pipeline-link"
-                    >
-                        Build a Pipeline
-                    </OutboundLink>
-                    <OutboundLink
-                        target="_blank"
-                        href="https://estuary.dev/vs-fivetran/"
-                        className="compare-link"
-                    >
-                        Compare to Fivetran
-                    </OutboundLink>
-                </div>
-            </div>
+  return (
+    <div className={`step-${activePage}`}>
+      <div className="step-content">
+        <div className="step-heading">Predictable Pricing</div>
+        <ul>
+          <li>
+            <b>{currencyFormatter.format(calculatePrice(1, 0).estuary)}</b>/GB
+          </li>
+          <li>
+            <b>{currencyFormatter.format(calculatePrice(0, 1).estuary)}</b>/task month
+          </li>
+          <li>Free for up to two tasks and 10 GB/month</li>
+        </ul>
+        <div className="step-ctas">
+          <OutboundLink target="_blank" href="https://dashboard.estuary.dev/register" className="pipeline-link">
+            Build a Pipeline
+          </OutboundLink>
+          <OutboundLink target="_blank" href="https://estuary.dev/vs-fivetran/" className="compare-link">
+            Compare to Fivetran
+          </OutboundLink>
         </div>
-    )
-}
+      </div>
+    </div>
+  );
+};
+
+export const Head = () => <Seo title="Estuary Walkthrough" />;
 
 const WhyEstuary = () => {
-    const [activePage, setActivePage] = React.useState(0)
-    console.log(activePage)
-    return (
-        <main className="why-estuary">
-            <div className="sidebar-wrap">
-                <div>
-                    <div className="sidebar-logo">
-                        <Link className="global-header-logo-link" to="/">
-                            <ColoredLogo
-                                className="global-header-logo"
-                                style={{ width: 27, height: 35 }}
-                            />
-                            <h1 className={"global-header-title"}>Estuary</h1>
-                        </Link>
-                    </div>
-                    <div className="sidebar-nav">
-                        <div
-                            className={`nav-item ${
-                                activePage === 0 ? "active" : ""
-                            }`}
-                            onClick={() => setActivePage(0)}
-                        >
-                            Welcome
-                        </div>
-                        <div
-                            className={`nav-item ${
-                                activePage === 1 ||
-                                activePage === 2 ||
-                                activePage === 3
-                                    ? "active"
-                                    : ""
-                            }`}
-                            onClick={() => setActivePage(1)}
-                        >
-                            Extract
-                        </div>
-                        <ul className="item-steps">
-                            <li
-                                className={`${activePage === 1 ? "active" : ""}`}
-                                onClick={() => setActivePage(1)}
-                            >
-                                Create Capture
-                            </li>
-                            <li
-                                className={`${activePage === 2 ? "active" : ""}`}
-                                onClick={() => setActivePage(2)}
-                            >
-                                Discover Schema
-                            </li>
-                            <li
-                                className={`${activePage === 3 ? "active" : ""}`}
-                                onClick={() => setActivePage(3)}
-                            >
-                                Monitoring
-                            </li>
-                        </ul>
-                        <div
-                            className={`nav-item ${
-                                activePage === 4 || activePage === 5 ? "active" : ""
-                            }`}
-                            onClick={() => setActivePage(4)}
-                        >
-                            Manage
-                        </div>
-                        <ul className="item-steps">
-                            <li
-                                className={`${activePage === 4 ? "active" : ""}`}
-                                onClick={() => setActivePage(4)}
-                            >
-                                Store history & real-time
-                            </li>
-                            <li
-                                className={`${activePage === 5 ? "active" : ""}`}
-                                onClick={() => setActivePage(5)}
-                            >
-                                Streaming SQL Transforms
-                            </li>
-                        </ul>
-                        <div
-                            className={`nav-item ${
-                                activePage === 6 ? "active" : ""
-                            }`}
-                            onClick={() => setActivePage(6)}
-                        >
-                            Load
-                        </div>
-                        <ul className="item-steps">
-                            <li
-                                className={`${activePage === 6 ? "active" : ""}`}
-                                onClick={() => setActivePage(6)}
-                            >
-                                Stream to destination
-                            </li>
-                        </ul>
-                        <div
-                            className={`nav-item ${
-                                activePage === 7 ? "active" : ""
-                            }`}
-                            onClick={() => setActivePage(7)}
-                        >
-                            Pricing
-                        </div>
-                        <ul className="item-steps">
-                            <li
-                                className={`${activePage === 7 ? "active" : ""}`}
-                                onClick={() => setActivePage(7)}
-                            >
-                                Flat Pricing
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div className="ctas-wrap">
-                    <OutboundLink
-                        target="_blank"
-                        href="https://dashboard.estuary.dev/register"
-                        className="pipeline-link"
-                    >
-                        Build a Pipeline
-                    </OutboundLink>
-                    <OutboundLink
-                        target="_blank"
-                        href="https://docs.estuary.dev/"
-                        className="doc-link"
-                    >
-                        View Docs
-                    </OutboundLink>
-                </div>
+  const [activePage, setActivePage] = React.useState(0);
+  return (
+    <main className="why-estuary">
+      <div className="sidebar-wrap">
+        <div>
+          <div className="sidebar-logo">
+            <Link className="global-header-logo-link" to="/">
+              <ColoredLogo className="global-header-logo" style={{ width: 27, height: 35 }} />
+              <h1 className={'global-header-title'}>Estuary</h1>
+            </Link>
+          </div>
+          <div className="sidebar-nav">
+            <div className={`nav-item ${activePage === 0 ? 'active' : ''}`} onClick={() => setActivePage(0)}>
+              Welcome
             </div>
-            <div className="main-content-wrap">
-                <div className={`mac-bg step-bg-${activePage}`}>
-                    {activePage === 0 && (
-                        <Step0
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 1 && (
-                        <Step1
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 2 && (
-                        <Step2
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 3 && (
-                        <Step3
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 4 && (
-                        <Step4
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 5 && (
-                        <Step5
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 6 && (
-                        <Step6
-                            activePage={activePage}
-                            setState={setActivePage}
-                        />
-                    )}
-                    {activePage === 7 && <Step7 activePage={activePage} />}
-                </div>
-                <div className="steps-controls">
-                    <div
-                        className="prev-step"
-                        onClick={() =>
-                            activePage === 0
-                                ? setActivePage(0)
-                                : setActivePage(activePage - 1)
-                        }
-                    >
-                        <span>Previous</span>
-                    </div>
-                    <div
-                        className="next-step"
-                        onClick={() =>
-                            activePage === 7
-                                ? setActivePage(7)
-                                : setActivePage(activePage + 1)
-                        }
-                    >
-                        <span>Next</span>
-                    </div>
-                </div>
+            <div
+              className={`nav-item ${activePage === 1 || activePage === 2 || activePage === 3 ? 'active' : ''}`}
+              onClick={() => setActivePage(1)}
+            >
+              Extract
             </div>
-        </main>
-    )
-}
+            <ul className="item-steps">
+              <li className={`${activePage === 1 ? 'active' : ''}`} onClick={() => setActivePage(1)}>
+                Create Capture
+              </li>
+              <li className={`${activePage === 2 ? 'active' : ''}`} onClick={() => setActivePage(2)}>
+                Discover Schema
+              </li>
+              <li className={`${activePage === 3 ? 'active' : ''}`} onClick={() => setActivePage(3)}>
+                Monitoring
+              </li>
+            </ul>
+            <div
+              className={`nav-item ${activePage === 4 || activePage === 5 ? 'active' : ''}`}
+              onClick={() => setActivePage(4)}
+            >
+              Manage
+            </div>
+            <ul className="item-steps">
+              <li className={`${activePage === 4 ? 'active' : ''}`} onClick={() => setActivePage(4)}>
+                Store history & real-time
+              </li>
+              <li className={`${activePage === 5 ? 'active' : ''}`} onClick={() => setActivePage(5)}>
+                Streaming SQL Transforms
+              </li>
+            </ul>
+            <div className={`nav-item ${activePage === 6 ? 'active' : ''}`} onClick={() => setActivePage(6)}>
+              Load
+            </div>
+            <ul className="item-steps">
+              <li className={`${activePage === 6 ? 'active' : ''}`} onClick={() => setActivePage(6)}>
+                Stream to destination
+              </li>
+            </ul>
+            <div className={`nav-item ${activePage === 7 ? 'active' : ''}`} onClick={() => setActivePage(7)}>
+              Pricing
+            </div>
+            <ul className="item-steps">
+              <li className={`${activePage === 7 ? 'active' : ''}`} onClick={() => setActivePage(7)}>
+                Flat Pricing
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div className="ctas-wrap">
+          <OutboundLink target="_blank" href="https://dashboard.estuary.dev/register" className="pipeline-link">
+            Build a Pipeline
+          </OutboundLink>
+          <OutboundLink target="_blank" href="https://docs.estuary.dev/" className="doc-link">
+            View Docs
+          </OutboundLink>
+        </div>
+      </div>
+      <div className="main-content-wrap">
+        <div className={`mac-bg step-bg-${activePage}`}>
+          {activePage === 0 && <Step0 activePage={activePage} setState={setActivePage} />}
+          {activePage === 1 && <Step1 activePage={activePage} setState={setActivePage} />}
+          {activePage === 2 && <Step2 activePage={activePage} setState={setActivePage} />}
+          {activePage === 3 && <Step3 activePage={activePage} setState={setActivePage} />}
+          {activePage === 4 && <Step4 activePage={activePage} setState={setActivePage} />}
+          {activePage === 5 && <Step5 activePage={activePage} setState={setActivePage} />}
+          {activePage === 6 && <Step6 activePage={activePage} setState={setActivePage} />}
+          {activePage === 7 && <Step7 activePage={activePage} />}
+        </div>
+        <div className="steps-controls">
+          <div
+            className="prev-step"
+            onClick={() => (activePage === 0 ? setActivePage(0) : setActivePage(activePage - 1))}
+          >
+            <span>Previous</span>
+          </div>
+          <div
+            className="next-step"
+            onClick={() => (activePage === 7 ? setActivePage(7) : setActivePage(activePage + 1))}
+          >
+            <span>Next</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};
 
-export default WhyEstuary
+export default WhyEstuary;

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -221,7 +221,7 @@ export const Step7 = ({ activePage }) => {
   );
 };
 
-export const Head = () => <Seo title="Walkthrough" />;
+export const Head = () => <Seo title="Walk through" />;
 
 const WhyEstuary = () => {
   const [activePage, setActivePage] = React.useState(0);

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -221,7 +221,7 @@ export const Step7 = ({ activePage }) => {
   );
 };
 
-export const Head = () => <Seo title="Walk through" />;
+export const Head = () => <Seo title="Walkthrough" />;
 
 const WhyEstuary = () => {
   const [activePage, setActivePage] = React.useState(0);

--- a/src/pages/why.tsx
+++ b/src/pages/why.tsx
@@ -221,7 +221,7 @@ export const Step7 = ({ activePage }) => {
   );
 };
 
-export const Head = () => <Seo title="Why" />;
+export const Head = () => <Seo title="Automate Data Streaming" />;
 
 const WhyEstuary = () => {
   const [activePage, setActivePage] = React.useState(0);


### PR DESCRIPTION
## Changes

https://github.com/estuary/marketing-site/issues/243
- Added the `Header` export on the three pages

## Tests / Screenshots

![image](https://github.com/estuary/marketing-site/assets/270078/4608e844-1ff5-436c-9a8b-593df5aeeb1a)

![image](https://github.com/estuary/marketing-site/assets/270078/a0b722f6-c40f-4f4b-9bb4-19ffd452ba65)

![image](https://github.com/estuary/marketing-site/assets/270078/9ddc3ec0-5e68-44f7-b870-7966387a3e89)

