### PR TITLE
Webinar:05-2024:Disable

### DIFF
--- a/src/components/TakeATour/index.tsx
+++ b/src/components/TakeATour/index.tsx
@@ -11,9 +11,9 @@ const DEFAULTS = {
 const SETTINGS = {
   ...DEFAULTS,
   // When there is a webinar uncomment below and provide the necessary details
-  href: 'https://content.estuary.dev/how-to-build-and-fix-cdc-pipelines-the-right-way',
-  message: 'How to Build and Fix CDC Pipelines the Right Way Webinar',
-  version: `/webinar_2024/05/13`,
+  // href: 'https://content.estuary.dev/how-to-build-and-fix-cdc-pipelines-the-right-way',
+  // message: 'How to Build and Fix CDC Pipelines the Right Way Webinar',
+  // version: `/webinar_2024/05/13`,
 };
 
 const STORAGE_KEY = `@estuary/closeTour${SETTINGS.version}`;


### PR DESCRIPTION
# DO NOT MERGE UNTIL MAY 23!

## Changes

- Removing the May 2024 webinar

## Tests / Screenshots

# Local
![image](https://github.com/estuary/marketing-site/assets/270078/883daf8e-161e-49fd-b8a1-5cff6b53b6c4)
