### PR TITLE
feat: add 'Need More' button for max connectors and GB

### DIFF
--- a/src/components/PricingCalculator/PricingCalculatorComparison.tsx
+++ b/src/components/PricingCalculator/PricingCalculatorComparison.tsx
@@ -1,25 +1,35 @@
 import * as React from "react"
+import OpenHubspotModal from "../HubSpot/OpenModal"
 import BrandCard from "./BrandCard"
 import { PricingCalculatorContext } from "./PricingCalculatorProvider"
 import { ComparisonWrapper } from "./styles"
 
 export const PricingCalculatorComparison = () => {
-  const { prices } = React.useContext(PricingCalculatorContext)
+  const { prices, selectedConnectors, selectedGbs } = React.useContext(PricingCalculatorContext)
 
   return (
     <ComparisonWrapper>
-      <BrandCard
-        title="ESTUARY"
-        price={prices.estuary}
-      />
-      <BrandCard
-        title="Confluent"
-        price={prices.confluent}
-      />
-      <BrandCard
-        title="Fivetran"
-        price={prices.fivetran}
-      />
+      {selectedConnectors === 21 || selectedGbs === 5 ? (
+        <OpenHubspotModal
+          buttonLabel="Need More?"
+          buttonId="section-one-hubspot"
+        />
+      ) : (
+        <>
+          <BrandCard
+            title="ESTUARY"
+            price={prices.estuary}
+          />
+          <BrandCard
+            title="Confluent"
+            price={prices.confluent}
+          />
+          <BrandCard
+            title="Fivetran"
+            price={prices.fivetran}
+          />
+        </>
+      )}
     </ComparisonWrapper>
   )
 }

--- a/src/components/PricingCalculator/PricingCalculatorSelector.tsx
+++ b/src/components/PricingCalculator/PricingCalculatorSelector.tsx
@@ -10,6 +10,8 @@ const inputLabel = 'Number of connectors';
 export const PricingCalculatorSelector = () => {
   const { selectedConnectors, setSelectedConnectors } = React.useContext(PricingCalculatorContext);
 
+  const maxConnectors = 21;
+
   const handleMinusClick = () => {
     setSelectedConnectors((c) => Math.max(2, c - 1));
   };
@@ -18,7 +20,11 @@ export const PricingCalculatorSelector = () => {
 
   const handleCountInputChange = (evt: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const value = parseInt(evt.target.value);
-    setSelectedConnectors(value >= 2 ? value : 2);
+
+    if (!Number.isNaN(value)) {
+      const clampedValue = Math.max(2, Math.min(maxConnectors, value));
+      setSelectedConnectors(clampedValue);
+    }
   };
 
   return (
@@ -34,6 +40,7 @@ export const PricingCalculatorSelector = () => {
           inputProps={{
             style: { textAlign: 'center' },
             min: 2,
+            max: maxConnectors
           }}
           type="number"
           value={selectedConnectors}
@@ -41,7 +48,7 @@ export const PricingCalculatorSelector = () => {
           notched
         />
       </Form>
-      <ButtonPlus onClick={handlePlusClick} aria-label={`increase ${inputLabel}`}>
+      <ButtonPlus onClick={handlePlusClick} disabled={selectedConnectors === maxConnectors} aria-label={`increase ${inputLabel}`}>
         <PlusSign />
       </ButtonPlus>
     </ConnectorsCounterWrapper>

--- a/src/components/PricingCalculator/styles.ts
+++ b/src/components/PricingCalculator/styles.ts
@@ -80,12 +80,13 @@ export const SliderWrapper = styled.div`
 export const ComparisonWrapper = styled.div`
   font-family: "Inter", sans-serif;
   display: flex;
-  align-items: center;
+  align-items: start;
   justify-content: center;
   width: 100%;
   margin-top: 32px;
   gap: 24px;
   flex-wrap: wrap;
+  min-height: 169px;
 
   @media (max-width: 525px) {
     gap: 32px;
@@ -105,6 +106,7 @@ export const BrandWrapper = styled.div`
   gap: 10px;
   width: 100%;
   max-width: 180px;
+  margin: auto 0;
 
   &:first-child {
     background-color: #5072EB12;
@@ -167,6 +169,9 @@ export const ConnectorsCounterWrapper = styled.div`
   display: flex;
   gap: 16px;
   margin-top: 16px;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
 `
 
 export const CountInputWrapper = styled.div`
@@ -188,6 +193,9 @@ export const ButtonPlus = styled(ButtonFilled)`
 `
 
 export const Form = styled(FormControl)`
+  max-width: 185px !important;
+  width: 100%;
+
   & > .MuiInputLabel-outlined {
     color: #04192B;
     width: 100%;


### PR DESCRIPTION
#309 

## Changes

-   Add "Need More?" button when number of connectors is > 20 or amount of change data is > 2.0 TB.

## Tests / Screenshots

-   Minimum:
![image](https://github.com/estuary/marketing-site/assets/60396753/32f4abf3-88ee-4c27-9e8e-d4de6750049e)

-   2 connectors and 2.0TB:
![image](https://github.com/estuary/marketing-site/assets/60396753/e38f19bd-b004-42a7-9407-f150030c80a5)

-   21 connectors and 2GB:
![image](https://github.com/estuary/marketing-site/assets/60396753/f0074ecc-7631-48f1-a592-c614af5c54a9)

-   All maximum:
![image](https://github.com/estuary/marketing-site/assets/60396753/62f52761-3e9c-4c16-98fb-b42f3341ded0)

