### PR TITLE
Brenosalv/bug/header-spacing-issue---connectordestination-template

### DIFF
--- a/src/templates/connector/ChangeData/style.ts
+++ b/src/templates/connector/ChangeData/style.ts
@@ -125,7 +125,5 @@ export const Topic = styled.li`
 `;
 
 export const LineBreak = styled.span`
-  @media (min-width: 1024px) {
-    display: block;
-  }
+  display: block;
 `;


### PR DESCRIPTION
#311 

## Changes

-   Add spacing to the connector page template -> section two title.

## Tests / Screenshots

-   Bug
![image](https://github.com/estuary/marketing-site/assets/60396753/54e355f1-4da8-4d9d-bba1-f1908b037213)

