### PR TITLE
Brenosalv/Bug/duplicated-estuary-in-the-head-title

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -54,7 +54,9 @@ const Seo: React.FC<SeoProps> = ({
     }
 
     const metaDescription = description ?? site.siteMetadata.description;
-    const defaultTitle = title.includes('Estuary |') ? '' : site.siteMetadata?.title;
+    const defaultTitle = title.includes('Estuary |')
+        ? ''
+        : site.siteMetadata?.title;
 
     return (
         <>

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -54,7 +54,7 @@ const Seo: React.FC<SeoProps> = ({
     }
 
     const metaDescription = description ?? site.siteMetadata.description;
-    const defaultTitle = site.siteMetadata?.title;
+    const defaultTitle = title.includes('Estuary |') ? '' : site.siteMetadata?.title;
 
     return (
         <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ import Seo from '../components/seo';
 
 const IndexPage = () => {
     return (
-        <Layout headerTheme="dark" showTour>
+        <Layout>
             <SectionOne />
             <SectionTwo />
             <SectionThree />


### PR DESCRIPTION
#329 

## Changes

- [x] Remove the last "| Estuary" when there is a "Estuary |" in the title already.

## Tests / Screenshots

-   ![image](https://github.com/estuary/marketing-site/assets/60396753/580b4279-879b-4a09-b2f7-3c8796a0f3d9)
