### PR TITLE
Brenosalv/bug/372-missing-a-space-on-the-home-page-forops-analytics-and-ai

### DIFF
--- a/src/components/Homepage/SectionTwo/index.tsx
+++ b/src/components/Homepage/SectionTwo/index.tsx
@@ -50,7 +50,7 @@ const SectionTwo = () => {
                     <span>and </span>
                     <span>transform </span>
                     <span>
-                        data in real-time with the only platform built for
+                        data in real-time with the only platform built for{' '}
                     </span>
                     <span>ops</span>
                     <span>, </span>


### PR DESCRIPTION
#372

## Changes

-   Add a space on the homepage section two text: FOR OPS, ANALYTICS, AND AI

## Tests / Screenshots
![image](https://github.com/estuary/marketing-site/assets/60396753/d8ed4f21-3a98-4343-9acd-e8c45496c01f)
