### PR TITLE
letting their be numbers in the connector image name

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 // NOTE: We're assuming that the image name follows the convention of
 // (source|materialization)-name
 // eslint-disable-next-line no-useless-escape
-const CONNECTOR_IMAGE_RE = /(source|materialize)-([a-z\-]+)/;
+const CONNECTOR_IMAGE_RE = /(source|materialize)-([a-z0-9\-]+)/;
 
 export const normalizeConnector = (connector: any) => {
     if (!connector) {


### PR DESCRIPTION
## Changes

- Update the regex to handle connector images with numbers in them. This is currently only needed for `S3` related connectors

## Tests / Screenshots

### All the connectors with `S3` in the name
![image](https://github.com/estuary/marketing-site/assets/270078/4f8c2197-628f-4a69-9c71-51fd7773bf0c)

![image](https://github.com/estuary/marketing-site/assets/270078/5d0faf6c-89df-4cdd-891a-1b5eba5e5d8d)

![image](https://github.com/estuary/marketing-site/assets/270078/b83a7f31-4cb5-49e4-a71e-ddcad48621e0)

![image](https://github.com/estuary/marketing-site/assets/270078/ed9d2841-a02b-4938-b742-90aadc89ccf9)

