### PR TITLE
Improve performance for blog posts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 public
+plugins
+patches

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 package.json
 package-lock.json
 public
+plugins
+patches

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -104,6 +104,7 @@ const cfg: GatsbyConfig = {
     flags: {
         PARALLEL_SOURCING: true,
         DEV_SSR: true,
+        DETECT_NODE_MUTATIONS: true,
     },
     // graphqlTypegen: true,
     plugins: [
@@ -211,8 +212,6 @@ const cfg: GatsbyConfig = {
             resolve: 'gatsby-plugin-styled-components',
             // https://styled-components.com/docs/tooling#babel-plugin
             options: {
-                ssr: false, // We need this to prevent mismatch errors
-                transpileTemplateLiterals: false, // Setting to false just to be safe - think we can remove in future
                 displayName: true, // Good to enable when debugging - but should not be needed for production
                 fileName: true, // We want to use the file in the style name
                 preprocess: false,

--- a/patches/gatsby-background-image+1.6.0.patch
+++ b/patches/gatsby-background-image+1.6.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/gatsby-background-image/lib/StyleUtils.js b/node_modules/gatsby-background-image/lib/StyleUtils.js
+index 1514d63..fe83fd0 100644
+--- a/node_modules/gatsby-background-image/lib/StyleUtils.js
++++ b/node_modules/gatsby-background-image/lib/StyleUtils.js
+@@ -25,7 +25,7 @@ var fixClassName = function fixClassName(_ref) {
+   var className = _ref.className,
+       props = (0, _objectWithoutPropertiesLoose2.default)(_ref, _excluded);
+   var convertedProps = (0, _HelperUtils.convertProps)(props);
+-  var elementExists = (0, _ClassCache.inComponentClassCache)(className);
++  var elementExists = false; //(0, _ClassCache.inComponentClassCache)(className);
+   var imageData = (0, _ImageUtils.getCurrentSrcData)(convertedProps);
+ 
+   var additionalClassname = _shortUuid.default.generate();

--- a/plugins/estuary-rehype-transformers/patches/gatsby-plugin-image+3.11.0.patch
+++ b/plugins/estuary-rehype-transformers/patches/gatsby-plugin-image+3.11.0.patch
@@ -1,15 +1,64 @@
-diff --git a/node_modules/gatsby-plugin-image/package.json b/node_modules/gatsby-plugin-image/package.json
-index 7d4912c..91bb78d 100644
---- a/node_modules/gatsby-plugin-image/package.json
-+++ b/node_modules/gatsby-plugin-image/package.json
-@@ -26,10 +26,6 @@
-   "main": "dist/gatsby-image.js",
-   "module": "dist/gatsby-image.module.js",
-   "esmodule": "dist/gatsby-image.modern.js",
--  "browser": {
--    "./dist/gatsby-image.js": "./dist/gatsby-image.browser.js",
--    "./dist/gatsby-image.module.js": "./dist/gatsby-image.browser.modern.js"
--  },
-   "files": [
-     "dist/*",
-     "gatsby-node.js",
+diff --git a/node_modules/gatsby-plugin-image/dist/components/hooks.js b/node_modules/gatsby-plugin-image/dist/components/hooks.js
+index 6148dc4..a3a91bd 100644
+--- a/node_modules/gatsby-plugin-image/dist/components/hooks.js
++++ b/node_modules/gatsby-plugin-image/dist/components/hooks.js
+@@ -148,7 +148,7 @@ function getMainProps(isLoading, isLoaded, images, loading, style) {
+     if (style === void 0) { style = {}; }
+     // fallback when it's not configured in gatsby-config.
+     if (!gatsbyImageIsInstalled()) {
+-        style = __assign({ height: "100%", left: 0, position: "absolute", top: 0, transform: "translateZ(0)", transition: "opacity 250ms linear", width: "100%", willChange: "opacity" }, style);
++        style = __assign({ height: "100%", left: '0px', position: "absolute", top: '0px', transform: "translateZ(0px)", transition: "opacity 250ms linear", width: "100%", willChange: "opacity" }, style);
+     }
+     var result = __assign(__assign({}, images), { loading: loading, shouldLoad: isLoading, "data-main-image": "", style: __assign(__assign({}, style), { opacity: isLoaded ? 1 : 0 }) });
+     return result;
+@@ -166,17 +166,17 @@ function getPlaceholderProps(placeholder, isLoaded, layout, width, height, backg
+         }
+         else if (layout === "constrained") {
+             wrapperStyle.position = "absolute";
+-            wrapperStyle.top = 0;
+-            wrapperStyle.left = 0;
+-            wrapperStyle.bottom = 0;
+-            wrapperStyle.right = 0;
++            wrapperStyle.top = '0px';
++            wrapperStyle.left = '0px';
++            wrapperStyle.bottom = '0px';
++            wrapperStyle.right = '0px';
+         }
+         else if (layout === "fullWidth") {
+             wrapperStyle.position = "absolute";
+-            wrapperStyle.top = 0;
+-            wrapperStyle.left = 0;
+-            wrapperStyle.bottom = 0;
+-            wrapperStyle.right = 0;
++            wrapperStyle.top = '0px';
++            wrapperStyle.left = '0px';
++            wrapperStyle.bottom = '0px';
++            wrapperStyle.right = '0px';
+         }
+     }
+     if (objectFit) {
+@@ -190,9 +190,9 @@ function getPlaceholderProps(placeholder, isLoaded, layout, width, height, backg
+     if (!gatsbyImageIsInstalled()) {
+         result.style = {
+             height: "100%",
+-            left: 0,
++            left: '0px',
+             position: "absolute",
+-            top: 0,
++            top: '0px',
+             width: "100%",
+         };
+     }
+diff --git a/node_modules/gatsby-plugin-image/dist/components/layout-wrapper.js b/node_modules/gatsby-plugin-image/dist/components/layout-wrapper.js
+index 7f0eaf1..469ddd1 100644
+--- a/node_modules/gatsby-plugin-image/dist/components/layout-wrapper.js
++++ b/node_modules/gatsby-plugin-image/dist/components/layout-wrapper.js
+@@ -64,7 +64,7 @@ function getSizer(layout, width, height) {
+         sizer = "<div aria-hidden=\"true\" style=\"padding-top: ".concat((height / width) * 100, "%;\"></div>");
+     }
+     if (layout === "constrained") {
+-        sizer = "<div style=\"max-width: ".concat(width, "px; display: block;\"><img alt=\"\" role=\"presentation\" aria-hidden=\"true\" src=\"data:image/svg+xml;charset=utf-8,%3Csvg%20height='").concat(height, "'%20width='").concat(width, "'%20xmlns='http://www.w3.org/2000/svg'%20version='1.1'%3E%3C/svg%3E\" style=\"max-width: 100%; display: block; position: static;\"></div>");
++        sizer = "<div style=\"max-width: ".concat(width,`${width > 0 ? 'px' : ''}`, "; display: block;\"><img alt=\"\" role=\"presentation\" aria-hidden=\"true\" src=\"data:image/svg+xml;charset=utf-8,%3Csvg%20height='").concat(height, "'%20width='").concat(width, "'%20xmlns='http://www.w3.org/2000/svg'%20version='1.1'%3E%3C/svg%3E\" style=\"max-width: 100%; display: block; position: static;\"></div>");
+     }
+     return sizer;
+ }

--- a/plugins/estuary-rehype-transformers/patches/gatsby-plugin-image+3.11.0.patch
+++ b/plugins/estuary-rehype-transformers/patches/gatsby-plugin-image+3.11.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/gatsby-plugin-image/dist/components/hooks.js b/node_modules/gatsby-plugin-image/dist/components/hooks.js
-index 6148dc4..a3a91bd 100644
+index 6148dc4..52231e2 100644
 --- a/node_modules/gatsby-plugin-image/dist/components/hooks.js
 +++ b/node_modules/gatsby-plugin-image/dist/components/hooks.js
 @@ -148,7 +148,7 @@ function getMainProps(isLoading, isLoaded, images, loading, style) {
@@ -37,7 +37,13 @@ index 6148dc4..a3a91bd 100644
          }
      }
      if (objectFit) {
-@@ -190,9 +190,9 @@ function getPlaceholderProps(placeholder, isLoaded, layout, width, height, backg
+@@ -185,14 +185,14 @@ function getPlaceholderProps(placeholder, isLoaded, layout, width, height, backg
+     if (objectPosition) {
+         wrapperStyle.objectPosition = objectPosition;
+     }
+-    var result = __assign(__assign({}, placeholder), { "aria-hidden": true, "data-placeholder-image": "", style: __assign({ opacity: isLoaded ? 0 : 1, transition: "opacity 500ms linear" }, wrapperStyle) });
++    var result = __assign(__assign({}, placeholder), { "data-estuary-custom-placeholder-patch":"", "aria-hidden": true, "data-placeholder-image": "", style: __assign({ opacity: isLoaded ? 0 : 1, transition: "opacity 500ms linear" }, wrapperStyle) });
+     // fallback when it's not configured in gatsby-config.
      if (!gatsbyImageIsInstalled()) {
          result.style = {
              height: "100%",


### PR DESCRIPTION
Removing linting/prettier from patches and plugins

## Changes

### Server Client mismatch
- Removing the `SSR` setting as that just hides the problem
- Adding more default options when starting dev server to catch possible issues
- Added some patch to the inline images so that they would set `0px` instead of `0` as that was getting picked up in the mismatch
     - ![image](https://github.com/estuary/marketing-site/assets/270078/51febbad-0708-429e-8147-29b432a51f6d)
 

### Misc
- Remove `plugin` and `patches` from lint and prettier

## Tests / Screenshots

### Background image

#### Prod 
![image](https://github.com/estuary/marketing-site/assets/270078/28fcbf18-c777-4724-8b7e-19445610eb0a)

#### Local - no longer adds extra random values
![image](https://github.com/estuary/marketing-site/assets/270078/18aa3faa-9d81-453a-aeb4-ee3abc5ff901)


