### PR TITLE
Brenosalv/feature/358-adjust-noreferrer-tags

### DIFF
--- a/src/components/Homepage/SectionFour/index.tsx
+++ b/src/components/Homepage/SectionFour/index.tsx
@@ -39,11 +39,7 @@ const SectionFour = () => {
                         <Advantage title="Most versatile writes that maintain a current view or all change history" />
                         <Advantage title="Most scalable pipelines, with true elastic scaling" />
                     </AdvantagesList>
-                    <Link
-                        to="/integrations"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
+                    <Link to="/integrations" target="_blank" rel="noopener">
                         View Connectors
                     </Link>
                 </LeftColumn>

--- a/src/components/Homepage/SectionThree/Card.tsx
+++ b/src/components/Homepage/SectionThree/Card.tsx
@@ -17,7 +17,7 @@ const Card = ({ href, title, description, image }: CardProps) => {
             <Button
                 to={href}
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 theme="dark"
                 aria-label={`Read case study for ${title}`}
             >

--- a/src/components/Integration/styles.module.less
+++ b/src/components/Integration/styles.module.less
@@ -1,6 +1,7 @@
 @import '../../globalStyles/sections.module.less';
 
 .description {
+  font-family: 'Inter', sans-serif;
   font-size: 1.5rem;
   line-height: 33.6px;
   font-weight: 300;
@@ -8,6 +9,10 @@
   display: inline;
   margin: 0;
   text-align: justify;
+
+  @media (max-width: 768px) {
+    text-align: left;
+  }
 }
 
 .connectorDescriptionContainer {


### PR DESCRIPTION
#358 

## Changes

-   Remove "noreferrer" from internal links.

## Tests / Screenshots
### Links that was removed the rel="noreferrer":

-   Homepage - Section three:
![image](https://github.com/user-attachments/assets/1bda0691-1942-433a-a4a9-6b301fc428fb)

-  Homepage - Section four:
![image](https://github.com/user-attachments/assets/7569ac60-90c0-4aad-9b33-81225be3a6b7)

### Leveraging this branch to solve another problem
-  Align connector's long/short description to the left on integration pages for tablet and mobile versions:

![image](https://github.com/user-attachments/assets/a099562b-0db9-48b3-b66f-25dc4bee7579)
![image](https://github.com/user-attachments/assets/a4b115b6-c2dd-4d2a-bcd0-38b6188dc096)
![image](https://github.com/user-attachments/assets/be755f6e-c6cb-4263-9a06-1513b2901d1b)
![image](https://github.com/user-attachments/assets/10fe1808-6f35-4b26-a483-cb5b8b4fdaa3)
