### PR TITLE
Brenosalv/bug/203-fix-blog-post-image-alt-text

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -179,7 +179,7 @@ const cfg: GatsbyConfig = {
                 // Plugins configs (optional but most likely you need one)
                 plugins: [
                     {
-                        resolve: `gatsby-rehype-inline-images`,
+                        resolve: '@draftbox-co/gatsby-rehype-inline-images',
                         // all options are optional and can be omitted
                         options: {
                             // all images larger are scaled down to maxWidth (default: maxWidth = imageWidth)

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -179,9 +179,9 @@ const cfg: GatsbyConfig = {
                 // Plugins configs (optional but most likely you need one)
                 plugins: [
                     {
-                        resolve: '@draftbox-co/gatsby-rehype-inline-images',
+                        resolve: `gatsby-rehype-inline-images`,
                         // all options are optional and can be omitted
-                        pluginOptions: {
+                        options: {
                             // all images larger are scaled down to maxWidth (default: maxWidth = imageWidth)
                             // maxWidth: 2000,
                             // disable, if you need to save memory


### PR DESCRIPTION
#203 

## Changes

-   Fix image alt texts from blog posts being undefined/null

## Tests / Screenshots
http://localhost:8000/avoid-mds-real-time-tax/:
![image](https://github.com/user-attachments/assets/1479c27f-a445-4be9-a928-d36081a50cdd)
