### PR TITLE
Brenosalv/seo/402-remove-h1-tag-from-logo-estuary and fix header responsiveness

### DIFF
--- a/src/components/Why/Navigation.tsx
+++ b/src/components/Why/Navigation.tsx
@@ -13,7 +13,7 @@ const Navigation = ({ activePage, setActivePage }) => (
                         className="global-header-logo"
                         style={{ width: 27, height: 35 }}
                     />
-                    <h1 className="global-header-title">Estuary</h1>
+                    <strong className="global-header-title">Estuary</strong>
                 </Link>
             </div>
             <div className="sidebar-nav">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -34,7 +34,7 @@ const Footer = () => {
                             layout="fixed"
                             placeholder="none"
                         />
-                        <h1 className="global-footer-title">Estuary</h1>
+                        <strong className="global-footer-title">Estuary</strong>
                     </Link>
                     <p className="global-footer-subtext">
                         Estuary provides real-time data integration and ETL for

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -165,7 +165,7 @@ const Header = ({ fixedHeader }: HeaderProps) => {
                             className="global-header-logo"
                             style={{ width: 27, height: 35 }}
                         />
-                        <h1 className="global-header-title">Estuary</h1>
+                        <strong className="global-header-title">Estuary</strong>
                     </Link>
                     <div className="global-header-wrapper">
                         <div

--- a/src/style.less
+++ b/src/style.less
@@ -295,6 +295,11 @@ span {
     height: 116px;
     top: 0;
 
+    @media (max-width: 1536px) {
+        padding-left: ~'calc(min(2vw,160px))';
+        padding-right: ~'calc(min(2vw,160px))';
+    }
+
     @media (max-width: 768px) {
         justify-content: space-between;
 
@@ -308,6 +313,12 @@ span {
         gap: 12px;
         padding-left: 7%;
         padding-right: 28px;
+
+        @media (max-width: 1280px) {
+            padding-left: 4%;
+            padding-right: 0;
+            gap: 0;
+        }
 
         .global-header-link {
             display: flex;


### PR DESCRIPTION
#347 
#402 

## Changes

-   Replace Estuary logo h1 with strong HTML element.
-   Fix header responsiveness to tablet and mobile screens.

## Tests / Screenshots

-   Header responsiveness:
![image](https://github.com/user-attachments/assets/b20b732d-610d-480f-9337-85740b53e841)

-   Replacing with strong tag on header:
![image](https://github.com/user-attachments/assets/d8056221-c15d-4c97-bc2c-edf8be069b66)

-   Replacing with strong tag on footer:
![image](https://github.com/user-attachments/assets/fcc7b8bc-4818-4541-8c13-2fc10ad127f5)
