### PR TITLE
Brenosalv/bug/estuary-logo-does-not-appear-in-safari

### DIFF
--- a/src/components/Integration/styles.module.less
+++ b/src/components/Integration/styles.module.less
@@ -107,6 +107,7 @@
 
 .sourceConnectorImage {
   max-width: 55%;
+  z-index: 5;
 
   @media (max-width: 768px) {
     max-width: 40%;

--- a/src/components/Integration/styles.module.less
+++ b/src/components/Integration/styles.module.less
@@ -107,7 +107,7 @@
 
 .sourceConnectorImage {
   max-width: 55%;
-  z-index: 5;
+  width: 100%;
 
   @media (max-width: 768px) {
     max-width: 40%;


### PR DESCRIPTION
#416 

## Changes

-   Estuary logo does not appear on first sections of integration page on Safari browser. We expect it to appear.

## Tests / Screenshots

-   scenarios you tested with screenshots
