### PR TITLE
Brenosalv/bug/364-the-hover-state-of-documents-link-from-menu-ends-up-wrapping

### DIFF
--- a/src/components/HeaderNavbar/Card/styles.ts
+++ b/src/components/HeaderNavbar/Card/styles.ts
@@ -1,12 +1,24 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { globalMaxWidth } from '../../../globalStyles';
+
+const adaptToHeaderMaxWidth = css`
+    @media (max-width: 1536px) {
+        padding-left: calc(min(2vw, 160px));
+        padding-right: calc(min(2vw, 160px));
+    }
+
+    @media (max-width: 1024px) {
+        padding-left: calc(min(10vw, 160px));
+        padding-right: calc(min(10vw, 160px));
+    }
+`;
 
 export const Wrapper = styled.div`
     width: 100%;
     background-color: #04192b;
     flex-direction: column;
 
-    @media (min-width: 1024px) {
+    @media (min-width: 1025px) {
         position: fixed;
         left: 50%;
         transform: translateX(-50%);
@@ -16,6 +28,7 @@ export const Wrapper = styled.div`
 
 export const Container = styled.div`
     ${globalMaxWidth};
+    ${adaptToHeaderMaxWidth};
 
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
@@ -34,7 +47,7 @@ export const Container = styled.div`
         max-height: 60vh;
     }
 
-    @media (max-width: 1023px) {
+    @media (max-width: 1024px) {
         grid-template-columns: 1fr 1fr;
         padding: 0 20px;
     }
@@ -47,6 +60,7 @@ export const Container = styled.div`
 
 export const Divider = styled.div`
     ${globalMaxWidth};
+    ${adaptToHeaderMaxWidth};
 
     background-clip: content-box;
     background-color: #1b3465;
@@ -55,9 +69,6 @@ export const Divider = styled.div`
 
     @media (max-width: 1024px) {
         margin: 12px 0;
-    }
-
-    @media (max-width: 1023px) {
         padding: 0;
     }
 

--- a/src/components/HeaderNavbar/styles.ts
+++ b/src/components/HeaderNavbar/styles.ts
@@ -13,7 +13,7 @@ export const ColumnWithTwoRows = styled.div`
     display: flex;
     flex-direction: column;
 
-    @media (min-width: 1024px) {
+    @media (min-width: 1025px) {
         gap: 38px;
     }
 

--- a/src/style.less
+++ b/src/style.less
@@ -426,7 +426,7 @@ span {
     margin-right: 5px;
     margin-top: 4px;
 
-    @media (min-width: 1024px) {
+    @media (min-width: 1025px) {
         width: 17px !important;
         height: 25px !important;
     }
@@ -445,7 +445,7 @@ span {
     font-weight: 600;
     margin: 31px 0;
 
-    @media (min-width: 1024px) {
+    @media (min-width: 1025px) {
         font-size: 18px;
     }
 
@@ -488,7 +488,7 @@ span {
     transition: background-color 150ms;
 
     &:hover {
-        @media (min-width: 1024px) {
+        @media (min-width: 1025px) {
             background-color: var(--header-link-hover);
         }
     }
@@ -2231,7 +2231,7 @@ table th {
 
 /* MEDIA QUERIES */
 
-@media (max-width: 1023px) {
+@media (max-width: 1024px) {
     main {
         margin-top: 100px;
     }


### PR DESCRIPTION
#364 

## Changes

-   Fix menu card title wrapping;
-   Fix Navbar messed up on screen width 1024px.

## Tests / Screenshots

-   Menu card title does not wrapping anymore:
![image](https://github.com/user-attachments/assets/7c65549d-c397-4840-a53a-81e4a67288c2)

-   Menu and divider are now adapted to new header width:
![image](https://github.com/user-attachments/assets/50a9e2f8-be3f-4819-af40-da89b8fff140)

-   Navbar adopts mobile style earlier (1024px instead of 1023px):
![image](https://github.com/user-attachments/assets/0ce6e021-3d6c-4e04-b929-a789b99cfe3b)

