### PR TITLE
Fix blog post image alt text

### DIFF
--- a/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
+++ b/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
-index 320309d..f5d6444 100644
+index 320309d..2a9fc55 100644
 --- a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 +++ b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 @@ -9,7 +9,7 @@ const {
@@ -40,7 +40,15 @@ index 320309d..f5d6444 100644
  
  const replaceNewImage = async (node, cache, store, createNode, createNodeId, reporter, options) => {
    //console.log(node);
-@@ -153,50 +149,24 @@ const generateImagesAndUpdateNode = async function ({
+@@ -117,6 +113,7 @@ const replaceNewImage = async (node, cache, store, createNode, createNodeId, rep
+   if (!imageNode) return;
+   let formattedImgTag = {};
+   formattedImgTag.url = url;
++  formattedImgTag.alt = node.properties.alt;
+   formattedImgTag.classList = node.properties.className || []; // formattedImgTag.title = thisImg.attr(`title`)
+   // formattedImgTag.alt = thisImg.attr(`alt`)
+ 
+@@ -153,50 +150,24 @@ const generateImagesAndUpdateNode = async function ({
  
    try {
      await sharp(imageNode.absolutePath).metadata();

--- a/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
+++ b/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
@@ -31,7 +31,7 @@ index 320309d..2a9fc55 100644
    const nodes = [];
    visit(htmlAst, {
      tagName: `img`
-@@ -83,11 +79,11 @@ module.exports = async ({
+@@ -83,7 +79,7 @@ module.exports = async ({
      return node;
    }));
    return htmlAst;


### PR DESCRIPTION
#203 

## Changes

-   Set missing alt text to formatted image element in package patch.

## Tests / Screenshots

<img width="1952" alt="image" src="https://github.com/user-attachments/assets/69076cd3-c34e-48af-8269-11ce699fab74">
