### PR TITLE
Replace Contact Us Gatsby Links with HTML anchors

### DIFF
--- a/src/components/HeaderNavbar/Resources/index.tsx
+++ b/src/components/HeaderNavbar/Resources/index.tsx
@@ -74,7 +74,7 @@ const HeaderNavbarResources = ({ active, setActive }) => {
                                 </ImageWrapper>
                                 <LinkOutlined
                                     target="_blank"
-                                    to="/why"
+                                    href="/why"
                                     theme="dark"
                                     $fullWidth
                                 >

--- a/src/components/Homepage/SectionOne/index.tsx
+++ b/src/components/Homepage/SectionOne/index.tsx
@@ -45,8 +45,9 @@ const SectionOne = () => {
                             Build a Pipeline
                         </PrimaryButton>
                         <SecondaryButton
-                            to="/contact-us"
+                            href="/contact-us"
                             className="homepage-section-one-button"
+                            target="_blank"
                         >
                             Contact Us
                         </SecondaryButton>

--- a/src/components/Homepage/SectionTen/index.tsx
+++ b/src/components/Homepage/SectionTen/index.tsx
@@ -20,7 +20,9 @@ const SectionTen = () => {
                 <OutboundLinkOutlined href={webinarsUrl} target="_blank">
                     Watch Demo
                 </OutboundLinkOutlined>
-                <HubspotButton to="/contact-us">Contact Us</HubspotButton>
+                <HubspotButton href="/contact-us" target="_blank">
+                    Contact Us
+                </HubspotButton>
             </Buttons>
         </Wrapper>
     );

--- a/src/components/Homepage/SectionThree/Card.tsx
+++ b/src/components/Homepage/SectionThree/Card.tsx
@@ -15,7 +15,7 @@ const Card = ({ href, title, description, image }: CardProps) => {
             <CardTitle>{title}</CardTitle>
             <CardDescription>{description}</CardDescription>
             <Button
-                to={href}
+                href={href}
                 target="_blank"
                 rel="noopener"
                 theme="dark"

--- a/src/components/Integration/SectionFive/index.tsx
+++ b/src/components/Integration/SectionFive/index.tsx
@@ -29,7 +29,7 @@ const SectionFive = () => {
                     >
                         Try Now
                     </OutboundLinkFilled>
-                    <LinkOutlined to="/contact-us" theme="dark">
+                    <LinkOutlined href="/contact-us" theme="dark">
                         Contact Us
                     </LinkOutlined>
                 </div>

--- a/src/components/Integration/SectionOne/index.tsx
+++ b/src/components/Integration/SectionOne/index.tsx
@@ -118,8 +118,9 @@ const SectionOne = ({ sourceConnector, destConnector }: SectionOneProps) => {
                         <span>Schedule an appointment</span>
                         <div className={buttonWrapper}>
                             <LinkOutlined
-                                to="/contact-us"
+                                href="/contact-us"
                                 className={secondaryButton}
+                                target="_blank"
                             >
                                 Contact Us
                             </LinkOutlined>

--- a/src/components/Product/SectionFourteen/index.tsx
+++ b/src/components/Product/SectionFourteen/index.tsx
@@ -53,7 +53,7 @@ const SectionFourteen = () => {
                                     overview.
                                 </BoxDescription>
                             </TextWrapper>
-                            <LinkOutlined to="/contact-us">
+                            <LinkOutlined href="/contact-us" target="_blank">
                                 <IconWrapper>
                                     <CalendarIcon color="#5072EB" />
                                 </IconWrapper>

--- a/src/components/Product/SectionOne/index.tsx
+++ b/src/components/Product/SectionOne/index.tsx
@@ -36,7 +36,7 @@ const SectionOne = () => {
                             >
                                 Build a Pipeline
                             </PrimaryButton>
-                            <SecondaryButton to="/contact-us">
+                            <SecondaryButton href="/contact-us" target="_blank">
                                 Contact Us
                             </SecondaryButton>
                         </ButtonsContainer>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -69,12 +69,13 @@ const Footer = () => {
                         >
                             Github
                         </OutboundLink>
-                        <Link
-                            to="/contact-us"
+                        <a
+                            href="/contact-us"
                             className="global-footer-right-link"
+                            target="_blank"
                         >
                             Contact Us
-                        </Link>
+                        </a>
                         <OutboundLink
                             target="_blank"
                             href="https://docs.estuary.dev/"

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -110,7 +110,7 @@ export const LinkFilled = styled(Link)`
     ${BaseButtonFilledStyling}
 `;
 
-export const LinkOutlined = styled(Link)<LinkOutlinedProps>`
+export const LinkOutlined = styled.a<LinkOutlinedProps>`
     ${(props) => baseButtonPrimaryStyling(props.theme)}
     width: ${(props) => (props.$fullWidth ? '100%' : 'auto')};
 

--- a/src/layouts/Pricing/Sections/Hero.tsx
+++ b/src/layouts/Pricing/Sections/Hero.tsx
@@ -22,7 +22,9 @@ const PricingHero = () => {
                     >
                         Build free pipeline
                     </OutboundLink>
-                    <LinkOutlined to="/contact-us">Contact Us</LinkOutlined>
+                    <LinkOutlined href="/contact-us" target="_blank">
+                        Contact Us
+                    </LinkOutlined>
                 </div>
             </div>
             <div className="image-container">

--- a/src/pages/podcasts.tsx
+++ b/src/pages/podcasts.tsx
@@ -153,7 +153,7 @@ const LpPodcats = () => {
                             <a href="https://dashboard.estuary.dev/register">
                                 Sign up
                             </a>
-                            <a href="https://estuary.dev/contact-us">
+                            <a href="/contact-us" target="_blank">
                                 Contact us
                             </a>
                         </div>


### PR DESCRIPTION
Append to the PR [443](https://github.com/estuary/marketing-site/pull/443).

## Changes

-   Replace Contact Us Gatsby Links with HTML anchors to open new tab on click.

