### PR TITLE
Switch compare pages to use Strapi content for seo description

### DIFF
--- a/src/templates/product-comparison.tsx
+++ b/src/templates/product-comparison.tsx
@@ -236,7 +236,7 @@ const ComparisonPageTemplate = ({
 
 export const Head = ({
     data: {
-        thisPage: { their_name },
+        thisPage: { their_name, MetaDescription },
     },
 }) => {
     const title = `Estuary Vs ${their_name}`;
@@ -245,23 +245,12 @@ export const Head = ({
     //  we switch to using the MetaDescription coming from Strapi. Should still leave the fallback
     //  of estuaryAllowsEnterprises just to be safe
     const description = React.useMemo(() => {
-        switch (their_name) {
-            case 'Fivetran':
-                return `Compare Estuary and Fivetran to optimize your data pipeline effectively. Assess Estuary's strengths in integration and flexibility against Fivetran's offerings.`;
-
-            case 'Airbyte':
-                return `Discover why Estuary excels compared to Airbyte in data integration. Explore features, scalability, and reliability to streamline your data management effortlessly.`;
-
-            case 'Confluent':
-                return `Discover why Estuary stands out compared to Confluent. Compare features, scalability, and ecosystem support to find the ideal streaming data platform for your needs.`;
-
-            case 'Debezium':
-                return `Discover why Estuary is the preferred choice over Debezium for change data capture. Compare features, performance, and integration capabilities to optimize your data streaming strategy.`;
-
-            default:
-                return estuaryAllowsEnterprises;
+        if (MetaDescription) {
+            return MetaDescription;
         }
-    }, [their_name]);
+
+        return estuaryAllowsEnterprises;
+    }, [MetaDescription]);
 
     return <Seo title={title} description={description} />;
 };
@@ -284,6 +273,7 @@ export const pageQuery = graphql`
         thisPage: strapiProductComparisonPage(id: { eq: $id }) {
             Slug
             their_name
+            MetaDescription
             logo {
                 localFile {
                     childImageSharp {

--- a/src/templates/product-comparison.tsx
+++ b/src/templates/product-comparison.tsx
@@ -241,9 +241,6 @@ export const Head = ({
 }) => {
     const title = `Estuary Vs ${their_name}`;
 
-    // This can be removed once https://github.com/estuary/strapi-admin/pull/13 is merged and
-    //  we switch to using the MetaDescription coming from Strapi. Should still leave the fallback
-    //  of estuaryAllowsEnterprises just to be safe
     const description = React.useMemo(() => {
         if (MetaDescription) {
             return MetaDescription;


### PR DESCRIPTION
https://github.com/estuary/marketing-site/issues/449

## Changes

- Remove hardcoded content and use the new property from Strapi

## Tests / Screenshots

![image](https://github.com/user-attachments/assets/312dc337-fd6e-424b-ab12-6e1b6f1db5ac)
![image](https://github.com/user-attachments/assets/eab561b9-9b7d-4ef1-8708-a3d8a0ad60de)
![image](https://github.com/user-attachments/assets/753862c4-6022-40d2-a859-48febbb7a111)
![image](https://github.com/user-attachments/assets/eb350304-3672-4a3d-88c9-5aebee597360)

