### PR TITLE
Collapse blog post table of contents on mobile

### DIFF
--- a/src/components/BlogPostToc.tsx
+++ b/src/components/BlogPostToc.tsx
@@ -1,5 +1,5 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Typography } from '@mui/material';
+import { Typography, useMediaQuery } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -107,6 +107,7 @@ export const RenderToc = ({ items }: { items: TocItem[] }) => {
         null
     );
     const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+    const isMobile = useMediaQuery('(max-width:768px)');
 
     React.useEffect(() => {
         intersectionObserver.current = new IntersectionObserver(
@@ -172,7 +173,11 @@ export const RenderToc = ({ items }: { items: TocItem[] }) => {
 
     return (
         <div className="table-of-contents">
-            <Accordion elevation={0} className="accordion" defaultExpanded>
+            <Accordion
+                elevation={0}
+                className="accordion"
+                defaultExpanded={!isMobile}
+            >
                 <AccordionSummary
                     className="accordion-side-padding"
                     expandIcon={

--- a/src/style.less
+++ b/src/style.less
@@ -4677,6 +4677,10 @@ table th {
             max-height: 20vh;
         }
 
+        @media (max-width: 425px) {
+            max-height: 40vh;
+        }
+
         h3 {
             margin: 0 0 8px;
             color: #04192b;

--- a/src/style.less
+++ b/src/style.less
@@ -4665,6 +4665,17 @@ table th {
         background: #ffffff;
         counter-reset: toc-counter;
         margin-top: 18px;
+        max-height: 45vh;
+        overflow: auto;
+        padding-right: 8px;
+
+        @media (max-height: 1128px) {
+            max-height: 36vh;
+        }
+
+        @media (max-height: 1000px) {
+            max-height: 20vh;
+        }
 
         h3 {
             margin: 0 0 8px;


### PR DESCRIPTION
#454 

## Changes

-   Collapse table of contents on mobile devices.
-   Add scroll to the table of contents for when it's big enough.
