### PR TITLE
Updating HubSpot eventing

### DIFF
--- a/src/components/HubSpot/FormWrapper.tsx
+++ b/src/components/HubSpot/FormWrapper.tsx
@@ -2,20 +2,28 @@ import { LinearProgress } from '@mui/material';
 import * as React from 'react';
 import HubspotForm from 'react-hubspot-form';
 
-function HubSpotFormWrapper() {
-    const handleSubmit = (event) => {
-        window.dataLayer?.push({
-            'event': 'hubspot_modal_form',
+const handleSubmit = (event) => {
+    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+        window.gtag('event', 'hubspot_form_submitted', {
             'hs-form-guid': event.formId,
         });
-    };
+    }
+};
 
+const handleLoad = () => {
+    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+        window.gtag('event', 'hubspot_form_loaded');
+    }
+};
+
+function HubSpotFormWrapper() {
     return (
         <HubspotForm
             loading={<LinearProgress />}
             portalId="8635875"
             formId="698e6716-f38b-4bd5-9105-df9ba220e29b"
             onSubmit={handleSubmit}
+            onReady={handleLoad}
         />
     );
 }


### PR DESCRIPTION
## Changes

- Submit the event through `gtag` and not directly in data layer
- Update events so they do not reference modal
- Add a "loaded" event

## Tests / Screenshots

### Load
![image](https://github.com/user-attachments/assets/c324c6b9-a778-4105-ac41-66c8cc717593)

### Submit
![image](https://github.com/user-attachments/assets/c47b140b-6c31-4eac-9f4a-a650de1150f6)

