### PR TITLE
Remove individual line-height from h1 styles

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -134,7 +134,6 @@ h1 {
     font-size: var(--fontSize-6);
     color: var(--color-heading-black);
     font-weight: var(--fontWeight-bold);
-    line-height: 72px;
     margin: 0;
 }
 


### PR DESCRIPTION
#472 

## Changes

-   Fix line-height of the h1 from the homepage section one.
-   This issue seems to happen only in production.
-   It was being set twice in the code:
<img width="286" alt="image" src="https://github.com/user-attachments/assets/bc4499e2-ceef-4ae8-b714-6041fc22bd9e">


## Tests / Screenshots

-   Tested locally:
<img width="1834" alt="image" src="https://github.com/user-attachments/assets/e9e8e481-f968-4552-89d1-e1eafdd92511">

