### PR TITLE
Add help text under the contact us form

### DIFF
--- a/src/components/ContactUs/SectionOne/index.tsx
+++ b/src/components/ContactUs/SectionOne/index.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import ContactUsForm from '../../ContactUsForm';
-import { section } from './styles.module.less';
+import { OutboundLink } from '../../OutboundLink';
+import { section, contactUsFormHelpText } from './styles.module.less';
 
 const SectionOne = () => {
     return (
         <section className={section}>
             <ContactUsForm titleHeadingLevel="h1" />
+            <p className={contactUsFormHelpText}>
+                If you don't see the form, please{' '}
+                <OutboundLink
+                    href="https://share.hsforms.com/1aY5nFvOLS9WRBd-boiDimw553hf"
+                    target="__blank"
+                >
+                    click here
+                </OutboundLink>
+                .
+            </p>
         </section>
     );
 };

--- a/src/components/ContactUs/SectionOne/index.tsx
+++ b/src/components/ContactUs/SectionOne/index.tsx
@@ -14,8 +14,8 @@ const SectionOne = () => {
                     target="__blank"
                 >
                     click here
-                </OutboundLink>
-                .
+                </OutboundLink>{' '}
+                to open it in a new tab.
             </p>
         </section>
     );

--- a/src/components/ContactUs/SectionOne/index.tsx
+++ b/src/components/ContactUs/SectionOne/index.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import ContactUsForm from '../../ContactUsForm';
 import { OutboundLink } from '../../OutboundLink';
-import { section, contactUsFormHelpText } from './styles.module.less';
+import {
+    section,
+    contactUsFormHelpText,
+    redirectLink,
+} from './styles.module.less';
 
 const SectionOne = () => {
     return (
         <section className={section}>
             <ContactUsForm titleHeadingLevel="h1" />
             <p className={contactUsFormHelpText}>
-                If you don't see the form, please{' '}
+                If you don&apos;t see the form, please{' '}
                 <OutboundLink
                     href="https://share.hsforms.com/1aY5nFvOLS9WRBd-boiDimw553hf"
                     target="__blank"
+                    className={redirectLink}
                 >
                     click here
                 </OutboundLink>{' '}

--- a/src/components/ContactUs/SectionOne/styles.module.less
+++ b/src/components/ContactUs/SectionOne/styles.module.less
@@ -10,3 +10,9 @@
   background-size: 35%;
   background-position-y: 100%;
 }
+
+.contactUsFormHelpText {
+  font-size: 0.875rem;
+  font-weight: 400;
+  text-align: center;
+}

--- a/src/components/ContactUs/SectionOne/styles.module.less
+++ b/src/components/ContactUs/SectionOne/styles.module.less
@@ -16,3 +16,12 @@
   font-weight: 400;
   text-align: center;
 }
+
+.redirectLink {
+  color: #5072eb;
+
+  &:hover {
+    text-underline-offset: 4px;
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
#462 

## Changes

-   Add text under the contact us form: If you don't see the form, please [click here](https://share.hsforms.com/1aY5nFvOLS9WRBd-boiDimw553hf) to open it in a new tab.

## Tests / Screenshots

<img width="982" alt="image" src="https://github.com/user-attachments/assets/e16c7410-2585-40d4-b591-03ecf70b4a47">
