### PR TITLE
Add role under author name next to the blog post avatar

### DIFF
--- a/src/components/Bio/index.tsx
+++ b/src/components/Bio/index.tsx
@@ -9,6 +9,7 @@ export interface BioProps {
     authors: {
         name: string;
         link: string;
+        role?: string;
         slug: string;
         picture?: {
             localFile?: {
@@ -27,7 +28,7 @@ const Bio = ({ authors }: BioProps) => {
 
     return (
         <div className={container}>
-            {authors.map(({ picture, name, slug }) => {
+            {authors.map(({ picture, name, role, slug }) => {
                 const image = getImage(
                     picture?.localFile?.childImageSharp?.gatsbyImageData
                 );
@@ -43,7 +44,10 @@ const Bio = ({ authors }: BioProps) => {
                             name={name ? name : ''}
                         />
                         {name ? (
-                            <strong className={authorName}>{name}</strong>
+                            <div className={authorName}>
+                                <strong>{name}</strong>{' '}
+                                {role ? <span>{role}</span> : ''}
+                            </div>
                         ) : null}
                     </Link>
                 );

--- a/src/components/Bio/styles.module.less
+++ b/src/components/Bio/styles.module.less
@@ -17,8 +17,17 @@
 
 .authorName {
   color: #47506d;
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 19.2px;
+  display: flex;
+  flex-direction: column;
   margin-left: 8px;
+  line-height: 19.2px;
+
+  strong {
+    font-weight: 600;
+  }
+
+  span {
+    font-weight: 400;
+    font-size: 0.875rem;
+  }
 }


### PR DESCRIPTION
## Changes

-   Add role under author name next to the blog post avatar.

## Tests / Screenshots

-  One author:
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/1bcc1e9f-46ac-48d7-bf8f-7d8cf30c2af0">

-  Three authors:
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/d54c36f9-9bb6-413a-a029-8046107fc081">

-   It's how it grows once the number of the blog post authors increases:
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/a6447a18-d989-43df-ae59-6b4553e0a430">

