### PR TITLE
Replace netsuite slug and add redirect to old link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -145,6 +145,11 @@
                 "source": "/source/s",
                 "destination": "/source/s3",
                 "type": 301
+            },
+            {
+                "source": "/source/netsuite-v",
+                "destination": "/source/netsuite-v2",
+                "type": 301
             }
         ],
         "public": "public",

--- a/src/components/DiagramConnectors/DiagramSourceConnectors/index.tsx
+++ b/src/components/DiagramConnectors/DiagramSourceConnectors/index.tsx
@@ -107,7 +107,7 @@ const DiagramSourceConnectors = ({
                 />
             </ConnectorsGroup>
             <ConnectorsGroup className="spacing-left">
-                <Connector to="/source/netsuite-v">
+                <Connector to="/source/netsuite-v2">
                     <LogoWrapper>
                         <StaticImage
                             placeholder="none"


### PR DESCRIPTION
#498

## Changes

-   Replace broken netsuite link with new slug;
-   Add redirect to broken link.
Old slug: netsuite-v
New working Slug: netsuite-v2


## Tests / Screenshots

<img width="252" alt="image" src="https://github.com/user-attachments/assets/012753d8-080d-4fee-bd0f-1d7288da9db6">

