### PR TITLE
Add subscription benefits below CTA buttons and testimonials section title

### DIFF
--- a/src/components/Homepage/SectionNine/index.tsx
+++ b/src/components/Homepage/SectionNine/index.tsx
@@ -7,6 +7,7 @@ const SectionNine = () => {
     return (
         <DarkSwoopingLinesLeftDirectionBackground>
             <Wrapper>
+                <h2>What Our Customers Are Saying</h2>
                 <TestimonialsCarousel />
             </Wrapper>
         </DarkSwoopingLinesLeftDirectionBackground>

--- a/src/components/Homepage/SectionNine/index.tsx
+++ b/src/components/Homepage/SectionNine/index.tsx
@@ -7,7 +7,7 @@ const SectionNine = () => {
     return (
         <DarkSwoopingLinesLeftDirectionBackground>
             <Wrapper>
-                <h2>What Our Customers Are Saying</h2>
+                <h2>What people are saying</h2>
                 <TestimonialsCarousel />
             </Wrapper>
         </DarkSwoopingLinesLeftDirectionBackground>

--- a/src/components/Homepage/SectionNine/styles.ts
+++ b/src/components/Homepage/SectionNine/styles.ts
@@ -3,4 +3,17 @@ import { globalMaxWidth } from '../../../globalStyles';
 
 export const Wrapper = styled.div`
     ${globalMaxWidth}
+
+    h2 {
+        font-size: 2.5rem;
+        font-weight: 600;
+        color: #5072eb;
+        text-align: center;
+        margin-bottom: 60px;
+        text-transform: uppercase;
+
+        @media (max-width: 425px) {
+            font-size: 1.75rem;
+        }
+    }
 `;

--- a/src/components/Homepage/SectionOne/index.tsx
+++ b/src/components/Homepage/SectionOne/index.tsx
@@ -5,6 +5,7 @@ import SingleDataflowIcon from '../../../svgs/metric-single-dataflow.svg';
 import MetricCard from '../../MetricCard';
 import VanityLogosMarquee from '../../VanityLogosMarquee';
 import { dashboardRegisterUrl } from '../../../../shared';
+import SubscriptionBenefits from '../../SubscriptionBenefits';
 import AnimFallback from './AnimFallback';
 import AnimatedHero from './AnimatedHero';
 import {
@@ -53,6 +54,7 @@ const SectionOne = () => {
                             Contact Us
                         </SecondaryButton>
                     </HomepageHeadingButtons>
+                    <SubscriptionBenefits />
                 </HomepageHeader>
                 <FlowAnimationContainer>
                     <React.Suspense fallback={AnimFallback}>

--- a/src/components/Homepage/SectionOne/styles.ts
+++ b/src/components/Homepage/SectionOne/styles.ts
@@ -70,6 +70,10 @@ export const HomepageHeader = styled.div`
     display: flex;
     flex-direction: column;
     margin: auto 0;
+
+    ul {
+        margin-top: 24px;
+    }
 `;
 
 export const HomepageTitle = styled.h1`

--- a/src/components/Product/SectionOne/index.tsx
+++ b/src/components/Product/SectionOne/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { dashboardRegisterUrl, webinarsUrl } from '../../../../shared';
 import { DefaultWrapperDarkBlue } from '../../../styles/wrappers';
 import { sectionOneImageWrapper } from '../../../globalStyles/sections.module.less';
+import SubscriptionBenefits from '../../SubscriptionBenefits';
 import Card from './Card';
 import {
     ButtonsContainer,
@@ -40,6 +41,7 @@ const SectionOne = () => {
                                 Contact Us
                             </SecondaryButton>
                         </ButtonsContainer>
+                        <SubscriptionBenefits />
                     </ContainerContent>
                     <div className={sectionOneImageWrapper}>
                         <StaticImage

--- a/src/components/Product/SectionOne/styles.ts
+++ b/src/components/Product/SectionOne/styles.ts
@@ -32,6 +32,10 @@ export const ContainerContent = styled.div`
     display: flex;
     flex-direction: column;
     flex: 1;
+
+    ul {
+        margin-top: 24px;
+    }
 `;
 
 export const Title = styled.h1`

--- a/src/components/SubscriptionBenefits/index.tsx
+++ b/src/components/SubscriptionBenefits/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import CheckmarkIcon from '../../svgs/checkmark.svg';
+import { container } from './styles.module.less';
+
+const SubscriptionBenefits = () => {
+    return (
+        <ul className={container}>
+            <li>
+                <div>
+                    <CheckmarkIcon width={14} color="#fff" />
+                </div>
+                <span>
+                    <span>No credit card</span> required
+                </span>
+            </li>
+            <li>
+                <div>
+                    <CheckmarkIcon width={14} color="#fff" />
+                </div>
+                <span>
+                    30 days <span>free trial</span>
+                </span>
+            </li>
+        </ul>
+    );
+};
+
+export default SubscriptionBenefits;

--- a/src/components/SubscriptionBenefits/styles.module.less
+++ b/src/components/SubscriptionBenefits/styles.module.less
@@ -9,7 +9,7 @@
   li {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 6px;
     margin: 0;
 
     div {
@@ -19,13 +19,13 @@
       padding: 4px;
       background-color: #6ED5D6;
       border-radius: 100%;
-      width: 24px;
-      height: 24px;
+      width: 16px;
+      height: 16px;
     }
   }
 
   span {
-    font-size: 1rem;
+    font-size: 0.75rem;
     line-height: 20px;
     font-weight: 500;
     color: #fff;

--- a/src/components/SubscriptionBenefits/styles.module.less
+++ b/src/components/SubscriptionBenefits/styles.module.less
@@ -1,0 +1,42 @@
+.container {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 12px;
+  column-gap: 32px;
+  margin: 0;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0;
+
+    div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px;
+      background-color: #6ED5D6;
+      border-radius: 100%;
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  span {
+    font-size: 1rem;
+    line-height: 20px;
+    font-weight: 500;
+    color: #fff;
+
+    @media (min-width: 321px) {
+      white-space: nowrap;
+    }
+
+    span {
+      font-weight: 700;
+      color: #5072EB;
+    }
+  }
+}


### PR DESCRIPTION
#499 

## Changes

-   Add subscription benefits below the CTA buttons o home and product pages;
-   Add heading h2 to testimonials section on homepage.

## Tests / Screenshots

Subscription benefits list:
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/509ff9b1-75e1-42f1-a572-b5c94b11de01">

Testimonials:
<img width="1613" alt="image" src="https://github.com/user-attachments/assets/76249fc4-3a3d-44cb-ba6d-5571c16bc003">
