### PR TITLE
Adding `updatedAt` to the blog post cards

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -269,6 +269,7 @@ const cfg: GatsbyConfig = {
                             id
                             title: Title
                             slug: Slug
+                            updatedAt(formatString: "MMMM D, YYYY")
                             publishedAt(formatString: "MMMM D, YYYY")
                             tags: tags {
                                 Name

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -269,7 +269,6 @@ const cfg: GatsbyConfig = {
                             id
                             title: Title
                             slug: Slug
-                            updatedAt(formatString: "MMMM D, YYYY")
                             publishedAt(formatString: "MMMM D, YYYY")
                             tags: tags {
                                 Name

--- a/src/components/BlogPostCard/index.tsx
+++ b/src/components/BlogPostCard/index.tsx
@@ -12,6 +12,7 @@ export interface BlogPostCardProps {
     title: string;
     slug: string;
     publishedAt: string;
+    updatedAt?: string;
     tags: {
         Name: string;
         Slug: string;
@@ -43,6 +44,7 @@ export const BlogPostCard = ({
     title,
     authors,
     publishedAt,
+    updatedAt,
 }: BlogPostCardProps) => (
     <Link to={`/${slug}`} className={blogsPostCard}>
         {hero ? (
@@ -54,7 +56,8 @@ export const BlogPostCard = ({
             />
         ) : null}
         <p className={blogsPostCardDetails}>
-            {authors.map((author) => author.name).join(', ')} · {publishedAt}
+            {authors.map((author) => author.name).join(', ')} ·{' '}
+            {updatedAt ?? publishedAt}
         </p>
         <div className={blogsPostCardTitle}>{title}</div>
     </Link>

--- a/src/templates/blog/index.tsx
+++ b/src/templates/blog/index.tsx
@@ -197,6 +197,7 @@ export const pageQuery = graphql`
             nodes {
                 title: Title
                 slug: Slug
+                updatedAt(formatString: "MMMM D, YYYY")
                 publishedAt(formatString: "MMMM D, YYYY")
                 tags: tags {
                     Name


### PR DESCRIPTION
## https://github.com/estuary/marketing-site/issues/494

- Added `updatedAt` to the queries
- Using that in cards but falling back

## Tests / Screenshots

### Updated Local
![image](https://github.com/user-attachments/assets/595abffb-9cc1-4f7b-9f53-a4368ccab66a)

### Old view
![image](https://github.com/user-attachments/assets/8e9c5d51-302a-4485-820d-4de28f5377e4)

