### PR TITLE
Remove duplicate pages for comparison x vs y and y vs x

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -152,28 +152,28 @@
                 "type": 301
             },
             {
+                "source": "/ELT-comparison-guide",
+                "destination": "/ELT-alternatives-guide",
+                "type": 301
+            },
+            {
                 "source": "/vs-fivetran",
                 "destination": "/etl-tools/estuary-vs-fivetran",
                 "type": 301
             },
             {
                 "source": "/vs-airbyte",
-                "destination": "/etl-tools/estuary-vs-airbyte",
+                "destination": "/etl-tools/airbyte-vs-estuary",
                 "type": 301
             },
             {
                 "source": "/vs-confluent",
-                "destination": "/etl-tools/estuary-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-estuary",
                 "type": 301
             },
             {
                 "source": "/vs-debezium",
-                "destination": "/etl-tools/estuary-vs-debezium-kafka",
-                "type": 301
-            },
-            {
-                "source": "/ELT-comparison-guide",
-                "destination": "/ELT-alternatives-guide",
+                "destination": "/etl-tools/debezium-kafka-vs-estuary",
                 "type": 301
             }
         ],

--- a/firebase.json
+++ b/firebase.json
@@ -175,6 +175,281 @@
                 "source": "/vs-debezium",
                 "destination": "/etl-tools/debezium-kafka-vs-estuary",
                 "type": 301
+            },
+            {
+                "source": "/etl-tools/debezium-kafka-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-debezium-kafka",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/estuary-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-estuary",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/fivetran-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-fivetran",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/hevo-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-hevo",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/informatica-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-informatica",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-confluent",
+                "destination": "/etl-tools/confluent-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/estuary-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-estuary",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/fivetran-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-fivetran",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/hevo-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-hevo",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/informatica-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-informatica",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-debezium-kafka",
+                "destination": "/etl-tools/debezium-kafka-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/fivetran-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-fivetran",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/hevo-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-hevo",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/informatica-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-informatica",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-estuary",
+                "destination": "/etl-tools/estuary-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/hevo-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-hevo",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/informatica-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-informatica",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-fivetran",
+                "destination": "/etl-tools/fivetran-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/informatica-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-informatica",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-hevo",
+                "destination": "/etl-tools/hevo-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/matillion-vs-informatica",
+                "destination": "/etl-tools/informatica-vs-matillion",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-informatica",
+                "destination": "/etl-tools/informatica-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-informatica",
+                "destination": "/etl-tools/informatica-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-informatica",
+                "destination": "/etl-tools/informatica-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-informatica",
+                "destination": "/etl-tools/informatica-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/meltano-vs-matillion",
+                "destination": "/etl-tools/matillion-vs-meltano",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-matillion",
+                "destination": "/etl-tools/matillion-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-matillion",
+                "destination": "/etl-tools/matillion-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-matillion",
+                "destination": "/etl-tools/matillion-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/rivery-vs-meltano",
+                "destination": "/etl-tools/meltano-vs-rivery",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-meltano",
+                "destination": "/etl-tools/meltano-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-meltano",
+                "destination": "/etl-tools/meltano-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/striim-vs-rivery",
+                "destination": "/etl-tools/rivery-vs-striim",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-rivery",
+                "destination": "/etl-tools/rivery-vs-talend",
+                "type": 301
+            },
+            {
+                "source": "/etl-tools/talend-vs-striim",
+                "destination": "/etl-tools/striim-vs-talend",
+                "type": 301
             }
         ],
         "public": "public",

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -123,7 +123,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
         };
     }>(`
         {
-            allStrapiComparison {
+            allStrapiComparison(sort: { slugKey: ASC }) {
                 nodes {
                     id
                     slugKey

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -135,13 +135,9 @@ export const createPages: GatsbyNode['createPages'] = async ({
     const vendors = comparisonVendors.data?.allStrapiComparison.nodes;
 
     if (vendors) {
-        vendors.forEach((xVendor) => {
-            vendors.forEach((yVendor) => {
-                if (
-                    xVendor.slugKey &&
-                    yVendor.slugKey &&
-                    xVendor.id !== yVendor.id
-                ) {
+        vendors.forEach((xVendor, i) => {
+            vendors.slice(i + 1).forEach((yVendor) => {
+                if (xVendor.slugKey && yVendor.slugKey) {
                     createPage({
                         path: `/${getComparisonSlug(
                             xVendor.slugKey,

--- a/shared.ts
+++ b/shared.ts
@@ -36,7 +36,13 @@ export const getAuthorPathBySlug = (slug: string) =>
 export const getComparisonSlug = (
     xVendorSlugKey: string,
     yVendorSlugKey: string
-) => `etl-tools/${xVendorSlugKey}-vs-${yVendorSlugKey}`;
+) => {
+    const [firstVendorSlugKey, secondVendorSlugKey] = [
+        xVendorSlugKey,
+        yVendorSlugKey,
+    ].sort();
+    return `etl-tools/${firstVendorSlugKey}-vs-${secondVendorSlugKey}`;
+};
 
 export interface SubText {
     data: {

--- a/src/components/HeaderNavbar/CardItem/index.tsx
+++ b/src/components/HeaderNavbar/CardItem/index.tsx
@@ -20,7 +20,7 @@ const ItemLink = ({ name, description, Image, to, hasChevronIcon }) => {
     const linkProps = to[0] === '/' ? { to } : { href: to, target: '_blank' };
 
     return (
-        <LinkElement {...linkProps} aria-label={`Read case study for ${name}`}>
+        <LinkElement {...linkProps} aria-label={`Read content of ${name}`}>
             <CardItem>
                 {Image ? (
                     <Icon>

--- a/src/components/HeaderNavbar/Product/items.tsx
+++ b/src/components/HeaderNavbar/Product/items.tsx
@@ -1,5 +1,6 @@
 import { StaticImage } from 'gatsby-plugin-image';
 import React from 'react';
+import { getComparisonSlug } from '../../../../shared';
 
 export const products = [
     {
@@ -18,10 +19,13 @@ export const products = [
     },
 ];
 
+const generateComparisonTo = (xVendorSlugKey, yVendorSlugKey) =>
+    `/${getComparisonSlug(xVendorSlugKey, yVendorSlugKey)}`;
+
 export const compare = [
     {
         name: 'Estuary vs. Fivetran',
-        to: '/etl-tools/estuary-vs-fivetran',
+        to: generateComparisonTo('estuary', 'fivetran'),
         hasChevronIcon: true,
         Image: () => (
             <StaticImage
@@ -34,7 +38,7 @@ export const compare = [
     },
     {
         name: 'Estuary vs. Confluent',
-        to: '/etl-tools/estuary-vs-confluent',
+        to: generateComparisonTo('confluent', 'estuary'),
         hasChevronIcon: true,
         Image: () => (
             <StaticImage
@@ -47,7 +51,7 @@ export const compare = [
     },
     {
         name: 'Estuary vs. Airbyte',
-        to: '/etl-tools/estuary-vs-airbyte',
+        to: generateComparisonTo('airbyte', 'estuary'),
         hasChevronIcon: true,
         Image: () => (
             <StaticImage
@@ -60,7 +64,7 @@ export const compare = [
     },
     {
         name: 'Estuary vs. Debezium',
-        to: '/etl-tools/estuary-vs-debezium-kafka',
+        to: generateComparisonTo('debezium-kafka', 'estuary'),
         hasChevronIcon: true,
         Image: () => (
             <StaticImage


### PR DESCRIPTION
#534 

## Changes

-   Removed duplicate page contents and URLs from comparison pages.
-   Added all the wrong indexed pages to redirect.
-   Now we generate all the pages in ascendent alphabetical order.