### PR TITLE
Reduce the breakpoint for the navbar to expand to full width

### DIFF
--- a/src/components/Header/styles.module.less
+++ b/src/components/Header/styles.module.less
@@ -11,7 +11,7 @@
   top: 0;
   background: #04192b;
 
-  @media (max-width: 1536px) {
+  @media (max-width: 1400px) {
     padding-left: ~'calc(min(2vw,160px))';
     padding-right: ~'calc(min(2vw,160px))';
   }


### PR DESCRIPTION
#524 

## Changes

-   Reduce the breakpoint for the navbar to expand to full width. Old one is 1536px and new one is 1400px.

## Tests / Screenshots

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/5772d115-276e-4728-a156-ae78783c0bf3">
