### PR TITLE
Add missing ai pipelines field and remove two fields

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -68,9 +68,6 @@ const strapiConfig = {
                             Operational_Analytics: {
                                 populate: '*',
                             },
-                            Data_Science_ML: {
-                                populate: '*',
-                            },
                             AI_Pipelines: {
                                 populate: '*',
                             },

--- a/shared.ts
+++ b/shared.ts
@@ -74,9 +74,7 @@ export interface Vendor {
     slugKey: string;
     useCases: {
         odsReplication: HasFeature;
-        historicalAnalytics: string;
         databaseReplication: string;
-        dataScienceMl: HasFeature;
         dataMigration: HasFeature;
         dataIntegration: HasFeature;
         aiPipelines: HasFeature;

--- a/src/components/EtlToolsXvsYPage/SectionTwo/UseCases/index.tsx
+++ b/src/components/EtlToolsXvsYPage/SectionTwo/UseCases/index.tsx
@@ -8,12 +8,11 @@ const rows = [
         key: 'databaseReplication',
     },
     { label: 'Replication to ODS', key: 'odsReplication' },
-    { label: 'Historical Analytics', key: 'historicalAnalytics' },
     { label: 'Op. data integration', key: 'dataIntegration' },
     { label: 'Data migration', key: 'dataMigration' },
     { label: 'Stream processing', key: 'streamProcessing' },
     { label: 'Operational Analytics', key: 'operationalAnalytics' },
-    { label: 'Data science and ML', key: 'dataScienceMl' },
+    { label: 'AI Pipelines', key: 'aiPipelines' },
 ];
 
 const UseCases = ({ xVendor, yVendor, estuaryVendor }: ComparisonVendors) => {

--- a/src/templates/etl-tools/index.tsx
+++ b/src/templates/etl-tools/index.tsx
@@ -28,6 +28,7 @@ const EtlTools = ({
         vendors: { nodes: vendors },
     },
 }: EtlToolsProps) => {
+    console.log(xVendor);
     return (
         <Layout>
             <SectionOne vendors={vendors} xVendor={xVendor} yVendor={yVendor} />
@@ -78,16 +79,7 @@ export const pageQuery = graphql`
                         }
                     }
                 }
-                historicalAnalytics: Historial_Analytics
                 databaseReplication: Database_Replication
-                dataScienceMl: Data_Science_ML {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 dataMigration: Data_Migration {
                     icon: Icon
                     subText: Sub_Text {
@@ -323,16 +315,7 @@ export const pageQuery = graphql`
                         }
                     }
                 }
-                historicalAnalytics: Historial_Analytics
                 databaseReplication: Database_Replication
-                dataScienceMl: Data_Science_ML {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 dataMigration: Data_Migration {
                     icon: Icon
                     subText: Sub_Text {
@@ -568,16 +551,7 @@ export const pageQuery = graphql`
                         }
                     }
                 }
-                historicalAnalytics: Historial_Analytics
                 databaseReplication: Database_Replication
-                dataScienceMl: Data_Science_ML {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 dataMigration: Data_Migration {
                     icon: Icon
                     subText: Sub_Text {


### PR DESCRIPTION
## Changes

-   Add missing `AI_Pipelines` field into comparison table > Use cases, and remove `Data_Science_ML` and `Historial_Analytics` fields as requested by Dani

-  We should make the same changes in Strapi Admin code.
