### PR TITLE
Fix banner background color from etl tools XvsY page

### DIFF
--- a/src/components/BlogBanner/styles.module.less
+++ b/src/components/BlogBanner/styles.module.less
@@ -57,6 +57,7 @@
   margin-right: auto;
   border-radius: 24px;
   overflow: hidden;
+  background-color: #04192B;
 
   @media (max-width: 1350px) {
     padding: 48px 30px;


### PR DESCRIPTION
#544 

## Changes

-   Fix banners background image from ETL Tools XvsY page 

## Tests / Screenshots

-  etl-tools page X vs Y:
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/acbd9fb2-4ce9-4563-bb59-9f11b842da32">

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/6d681845-af6f-42e4-8e75-e7e4b408bfd7">