### PR TITLE
Add ending slash to comparison URLs and update description on homepage hero section

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -158,297 +158,297 @@
             },
             {
                 "source": "/vs-fivetran",
-                "destination": "/etl-tools/estuary-vs-fivetran",
+                "destination": "/etl-tools/estuary-vs-fivetran/",
                 "type": 301
             },
             {
                 "source": "/vs-airbyte",
-                "destination": "/etl-tools/airbyte-vs-estuary",
+                "destination": "/etl-tools/airbyte-vs-estuary/",
                 "type": 301
             },
             {
                 "source": "/vs-confluent",
-                "destination": "/etl-tools/confluent-vs-estuary",
+                "destination": "/etl-tools/confluent-vs-estuary/",
                 "type": 301
             },
             {
                 "source": "/vs-debezium",
-                "destination": "/etl-tools/debezium-kafka-vs-estuary",
+                "destination": "/etl-tools/debezium-kafka-vs-estuary/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/debezium-kafka-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-debezium-kafka",
+                "source": "/etl-tools/debezium-kafka-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-debezium-kafka/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/estuary-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-estuary",
+                "source": "/etl-tools/estuary-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-estuary/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/fivetran-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-fivetran",
+                "source": "/etl-tools/fivetran-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-fivetran/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/hevo-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-hevo",
+                "source": "/etl-tools/hevo-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-hevo/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/informatica-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-informatica",
+                "source": "/etl-tools/informatica-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-informatica/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-matillion",
+                "source": "/etl-tools/matillion-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-meltano",
+                "source": "/etl-tools/meltano-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-rivery",
+                "source": "/etl-tools/rivery-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-striim",
+                "source": "/etl-tools/striim-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-confluent",
-                "destination": "/etl-tools/confluent-vs-talend",
+                "source": "/etl-tools/talend-vs-confluent/",
+                "destination": "/etl-tools/confluent-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/estuary-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-estuary",
+                "source": "/etl-tools/estuary-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-estuary/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/fivetran-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-fivetran",
+                "source": "/etl-tools/fivetran-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-fivetran/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/hevo-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-hevo",
+                "source": "/etl-tools/hevo-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-hevo/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/informatica-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-informatica",
+                "source": "/etl-tools/informatica-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-informatica/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-matillion",
+                "source": "/etl-tools/matillion-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-meltano",
+                "source": "/etl-tools/meltano-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-rivery",
+                "source": "/etl-tools/rivery-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-striim",
+                "source": "/etl-tools/striim-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-debezium-kafka",
-                "destination": "/etl-tools/debezium-kafka-vs-talend",
+                "source": "/etl-tools/talend-vs-debezium-kafka/",
+                "destination": "/etl-tools/debezium-kafka-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/fivetran-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-fivetran",
+                "source": "/etl-tools/fivetran-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-fivetran/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/hevo-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-hevo",
+                "source": "/etl-tools/hevo-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-hevo/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/informatica-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-informatica",
+                "source": "/etl-tools/informatica-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-informatica/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-matillion",
+                "source": "/etl-tools/matillion-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-meltano",
+                "source": "/etl-tools/meltano-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-rivery",
+                "source": "/etl-tools/rivery-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-striim",
+                "source": "/etl-tools/striim-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-estuary",
-                "destination": "/etl-tools/estuary-vs-talend",
+                "source": "/etl-tools/talend-vs-estuary/",
+                "destination": "/etl-tools/estuary-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/hevo-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-hevo",
+                "source": "/etl-tools/hevo-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-hevo/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/informatica-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-informatica",
+                "source": "/etl-tools/informatica-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-informatica/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-matillion",
+                "source": "/etl-tools/matillion-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-meltano",
+                "source": "/etl-tools/meltano-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-rivery",
+                "source": "/etl-tools/rivery-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-striim",
+                "source": "/etl-tools/striim-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-fivetran",
-                "destination": "/etl-tools/fivetran-vs-talend",
+                "source": "/etl-tools/talend-vs-fivetran/",
+                "destination": "/etl-tools/fivetran-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/informatica-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-informatica",
+                "source": "/etl-tools/informatica-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-informatica/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-matillion",
+                "source": "/etl-tools/matillion-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-meltano",
+                "source": "/etl-tools/meltano-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-rivery",
+                "source": "/etl-tools/rivery-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-striim",
+                "source": "/etl-tools/striim-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-hevo",
-                "destination": "/etl-tools/hevo-vs-talend",
+                "source": "/etl-tools/talend-vs-hevo/",
+                "destination": "/etl-tools/hevo-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/matillion-vs-informatica",
-                "destination": "/etl-tools/informatica-vs-matillion",
+                "source": "/etl-tools/matillion-vs-informatica/",
+                "destination": "/etl-tools/informatica-vs-matillion/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-informatica",
-                "destination": "/etl-tools/informatica-vs-meltano",
+                "source": "/etl-tools/meltano-vs-informatica/",
+                "destination": "/etl-tools/informatica-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-informatica",
-                "destination": "/etl-tools/informatica-vs-rivery",
+                "source": "/etl-tools/rivery-vs-informatica/",
+                "destination": "/etl-tools/informatica-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-informatica",
-                "destination": "/etl-tools/informatica-vs-striim",
+                "source": "/etl-tools/striim-vs-informatica/",
+                "destination": "/etl-tools/informatica-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-informatica",
-                "destination": "/etl-tools/informatica-vs-talend",
+                "source": "/etl-tools/talend-vs-informatica/",
+                "destination": "/etl-tools/informatica-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/meltano-vs-matillion",
-                "destination": "/etl-tools/matillion-vs-meltano",
+                "source": "/etl-tools/meltano-vs-matillion/",
+                "destination": "/etl-tools/matillion-vs-meltano/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-matillion",
-                "destination": "/etl-tools/matillion-vs-rivery",
+                "source": "/etl-tools/rivery-vs-matillion/",
+                "destination": "/etl-tools/matillion-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-matillion",
-                "destination": "/etl-tools/matillion-vs-striim",
+                "source": "/etl-tools/striim-vs-matillion/",
+                "destination": "/etl-tools/matillion-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-matillion",
-                "destination": "/etl-tools/matillion-vs-talend",
+                "source": "/etl-tools/talend-vs-matillion/",
+                "destination": "/etl-tools/matillion-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/rivery-vs-meltano",
-                "destination": "/etl-tools/meltano-vs-rivery",
+                "source": "/etl-tools/rivery-vs-meltano/",
+                "destination": "/etl-tools/meltano-vs-rivery/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-meltano",
-                "destination": "/etl-tools/meltano-vs-striim",
+                "source": "/etl-tools/striim-vs-meltano/",
+                "destination": "/etl-tools/meltano-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-meltano",
-                "destination": "/etl-tools/meltano-vs-talend",
+                "source": "/etl-tools/talend-vs-meltano/",
+                "destination": "/etl-tools/meltano-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/striim-vs-rivery",
-                "destination": "/etl-tools/rivery-vs-striim",
+                "source": "/etl-tools/striim-vs-rivery/",
+                "destination": "/etl-tools/rivery-vs-striim/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-rivery",
-                "destination": "/etl-tools/rivery-vs-talend",
+                "source": "/etl-tools/talend-vs-rivery/",
+                "destination": "/etl-tools/rivery-vs-talend/",
                 "type": 301
             },
             {
-                "source": "/etl-tools/talend-vs-striim",
-                "destination": "/etl-tools/striim-vs-talend",
+                "source": "/etl-tools/talend-vs-striim/",
+                "destination": "/etl-tools/striim-vs-talend/",
                 "type": 301
             }
         ],

--- a/shared.ts
+++ b/shared.ts
@@ -41,7 +41,7 @@ export const getComparisonSlug = (
         xVendorSlugKey,
         yVendorSlugKey,
     ].sort();
-    return `etl-tools/${firstVendorSlugKey}-vs-${secondVendorSlugKey}`;
+    return `etl-tools/${firstVendorSlugKey}-vs-${secondVendorSlugKey}/`;
 };
 
 export interface SubText {

--- a/src/components/Homepage/Hero/index.tsx
+++ b/src/components/Homepage/Hero/index.tsx
@@ -34,9 +34,9 @@ const Hero = () => {
                         <span className="white-text">ETL</span>
                     </HomepageTitle>
                     <HomepageDescription>
-                        The only platform built from the ground up for truly
-                        real-time ETL and ELT data integration, set up in
-                        minutes.
+                        Estuary is the only platform built from the ground up
+                        for truly real-time ETL and ELT data integration, set up
+                        in minutes.
                     </HomepageDescription>
                     <HomepageHeadingButtons>
                         <PrimaryButton

--- a/src/components/Product/SectionTwelve/index.tsx
+++ b/src/components/Product/SectionTwelve/index.tsx
@@ -17,7 +17,7 @@ const SectionTwelve = () => {
                     <PipelinesTable />
                 </TableWrapper>
                 <LinkFilled
-                    href="/etl-tools/estuary-vs-fivetran"
+                    href="/etl-tools/estuary-vs-fivetran/"
                     target="_blank"
                     aria-label="Estuary Flow Comparison versus Fivetran"
                 >

--- a/src/templates/connector/Pipelines/index.tsx
+++ b/src/templates/connector/Pipelines/index.tsx
@@ -21,7 +21,7 @@ const Pipelines = () => {
                 </Title>
                 <Description>Feature Comparison</Description>
                 <PipelinesTable />
-                <Button target="_blank" href="/etl-tools/estuary-vs-fivetran">
+                <Button target="_blank" href="/etl-tools/estuary-vs-fivetran/">
                     Detailed Comparison
                 </Button>
             </Container>


### PR DESCRIPTION
#547 

## Changes

-   Add ending slash to comparison URLs, including redirect slugs, `getComparisonSlug` function and some links/buttons from some pages.
-   Update the homepage hero section description for SEO purposes.

## Tests / Screenshots

Homepage description update:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/812bc4ce-0dfa-4a0c-abac-25ebf5d0313c">

