### PR TITLE
Adding more detail about authors for SEO

### DIFF
--- a/shared.ts
+++ b/shared.ts
@@ -44,8 +44,8 @@ export const getAuthorSeoJson = (author: Author, siteUrl: string) => {
 
     const sameAs: string[] = [];
 
-    if (author.socials.linkedIn) {
-        sameAs.push(author.socials.linkedIn);
+    if (author.socials.linked_in) {
+        sameAs.push(author.socials.linked_in);
     }
 
     if (author.socials.twitter) {

--- a/shared.ts
+++ b/shared.ts
@@ -44,8 +44,8 @@ export const getAuthorSeoJson = (author: Author, siteUrl: string) => {
 
     const sameAs: string[] = [];
 
-    if (author.socials.linked_in) {
-        sameAs.push(author.socials.linked_in);
+    if (author.socials.linkedIn) {
+        sameAs.push(author.socials.linkedIn);
     }
 
     if (author.socials.twitter) {

--- a/shared.ts
+++ b/shared.ts
@@ -1,5 +1,6 @@
 import { htmlToText } from 'html-to-text';
 import { features } from './src/components/DeploymentOptionsPage/shared';
+import { Author } from './src/templates/author/shared';
 
 export const webinarsUrl =
     'https://try.estuary.dev/webinar-estuary101-ondemand';
@@ -36,23 +37,23 @@ export const estuaryAddress = {
 export const getAuthorPathBySlug = (slug: string) =>
     `/author/${slug.toLowerCase()}`;
 
-export const getAuthorSeoJson = (author: any, siteUrl: string) => {
+export const getAuthorSeoJson = (author: Author, siteUrl: string) => {
     const authorBio = author.bio.data.bio
         ? htmlToText(author.bio.data.bio, { wordwrap: false })
         : 'Blog post author.';
 
     const sameAs: string[] = [];
 
-    if (author.socials?.linked_in) {
-        sameAs.push(author.socials?.linked_in);
+    if (author.socials.linked_in) {
+        sameAs.push(author.socials.linked_in);
     }
 
-    if (author.socials?.twitter) {
-        sameAs.push(author.socials?.twitter);
+    if (author.socials.twitter) {
+        sameAs.push(author.socials.twitter);
     }
 
-    if (author.socials?.other) {
-        sameAs.push(author.socials?.other);
+    if (author.socials.other) {
+        sameAs.push(author.socials.other);
     }
 
     return {
@@ -60,7 +61,7 @@ export const getAuthorSeoJson = (author: any, siteUrl: string) => {
         '@type': 'Person',
         'name': author.name,
         'url': `${siteUrl}${getAuthorPathBySlug(author.slug)}/`,
-        'jobTitle': author.role ?? '',
+        'jobTitle': author.role,
         'description': authorBio,
         'worksFor': {
             '@type': 'Organization',

--- a/shared.ts
+++ b/shared.ts
@@ -44,15 +44,15 @@ export const getAuthorSeoJson = (author: Author, siteUrl: string) => {
 
     const sameAs: string[] = [];
 
-    if (author.socials.linked_in) {
+    if (author.socials?.linked_in) {
         sameAs.push(author.socials.linked_in);
     }
 
-    if (author.socials.twitter) {
+    if (author.socials?.twitter) {
         sameAs.push(author.socials.twitter);
     }
 
-    if (author.socials.other) {
+    if (author.socials?.other) {
         sameAs.push(author.socials.other);
     }
 

--- a/shared.ts
+++ b/shared.ts
@@ -1,3 +1,4 @@
+import { htmlToText } from 'html-to-text';
 import { features } from './src/components/DeploymentOptionsPage/shared';
 
 export const webinarsUrl =
@@ -34,6 +35,48 @@ export const estuaryAddress = {
 
 export const getAuthorPathBySlug = (slug: string) =>
     `/author/${slug.toLowerCase()}`;
+
+export const getAuthorSeoJson = (author: any, siteUrl: string) => {
+    const authorBio = author.bio.data.bio
+        ? htmlToText(author.bio.data.bio, { wordwrap: false })
+        : 'Blog post author.';
+
+    const sameAs: string[] = [];
+
+    if (author.socials?.linked_in) {
+        sameAs.push(author.socials?.linked_in);
+    }
+
+    if (author.socials?.twitter) {
+        sameAs.push(author.socials?.twitter);
+    }
+
+    if (author.socials?.other) {
+        sameAs.push(author.socials?.other);
+    }
+
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        'name': author.name,
+        'url': `${siteUrl}${getAuthorPathBySlug(author.slug)}/`,
+        'jobTitle': author.role ?? '',
+        'description': authorBio,
+        'worksFor': {
+            '@type': 'Organization',
+            'name': 'Estuary',
+            'url': 'https://estuary.dev/',
+        },
+        sameAs,
+        'image': author.picture?.localFile?.childImageSharp?.fixedImg?.images
+            ?.fallback?.src
+            ? {
+                  '@type': 'ImageObject',
+                  'url': `${siteUrl}${author.picture.localFile.childImageSharp.fixedImg.images.fallback.src}`,
+              }
+            : undefined,
+    };
+};
 
 export const getComparisonSlug = (
     xVendorSlugKey: string,

--- a/src/components/SocialLinks/index.tsx
+++ b/src/components/SocialLinks/index.tsx
@@ -11,7 +11,7 @@ const iconColor = '#47506D';
 
 interface SocialLinks {
     socialLinks: {
-        linkedIn: string;
+        linked_in: string;
         twitter: string;
         other: string;
     };

--- a/src/templates/author/index.tsx
+++ b/src/templates/author/index.tsx
@@ -1,8 +1,8 @@
 import { graphql } from 'gatsby';
 import React from 'react';
-import { htmlToText } from 'html-to-text';
 import Layout from '../../components/Layout';
 import Seo from '../../components/seo';
+import { getAuthorSeoJson } from '../../../shared';
 import SectionOne from './SectionOne';
 import { Author } from './shared';
 import SectionTwo from './SectionTwo';
@@ -43,23 +43,33 @@ export default AuthorPage;
 
 export const Head = ({
     data: {
-        author: { name, bio },
+        author,
+        site: {
+            siteMetadata: { siteUrl },
+        },
     },
 }) => {
+    console.log('author', author);
+
+    const seoJson = getAuthorSeoJson(author, siteUrl);
+
     return (
-        <Seo
-            title={name}
-            description={
-                bio.data.bio
-                    ? htmlToText(bio.data.bio, { wordwrap: false })
-                    : 'Blog post author.'
-            }
-        />
+        <>
+            <Seo title={author.name} description={seoJson.description} />
+            <script type="application/ld+json">
+                {JSON.stringify(seoJson)}
+            </script>
+        </>
     );
 };
 
 export const pageQuery = graphql`
     query AuthorById($id: String!) {
+        site {
+            siteMetadata {
+                siteUrl
+            }
+        }
         author: strapiAuthor(id: { eq: $id }) {
             id
             name: Name
@@ -71,6 +81,7 @@ export const pageQuery = graphql`
                             height: 208
                             placeholder: BLURRED
                         )
+                        fixedImg: gatsbyImageData(layout: FIXED, width: 60)
                     }
                 }
             }

--- a/src/templates/author/index.tsx
+++ b/src/templates/author/index.tsx
@@ -49,8 +49,6 @@ export const Head = ({
         },
     },
 }) => {
-    console.log('author', author);
-
     const seoJson = getAuthorSeoJson(author, siteUrl);
 
     return (

--- a/src/templates/author/shared.ts
+++ b/src/templates/author/shared.ts
@@ -3,10 +3,10 @@ export interface Author {
     name: string;
     picture: any;
     slug: string;
-    socials: {
-        linked_in: string;
-        twitter: string;
-        other: string;
+    socials?: {
+        linked_in?: string;
+        twitter?: string;
+        other?: string;
     };
     bio: {
         data: {

--- a/src/templates/author/shared.ts
+++ b/src/templates/author/shared.ts
@@ -4,7 +4,7 @@ export interface Author {
     picture: any;
     slug: string;
     socials: {
-        linkedIn: string;
+        linked_in: string;
         twitter: string;
         other: string;
     };

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -207,113 +207,126 @@ const BlogPostTemplate = ({ data: { post } }) => {
                         </div>
                     </section>
                 ) : null}
-                <section className={nextStepsAndAboutAuthorSection}>
-                    {/* <div className={nextSteps}>
+                {post?.authors.length >= 1 ? (
+                    <section className={nextStepsAndAboutAuthorSection}>
+                        {/* <div className={nextSteps}>
                         <h3>Next steps</h3>
                         <NextStepsLink href="">Read about Lorem ipsum dolor sit amet, consectetur</NextStepsLink>
                         <NextStepsLink href="">Learn about Lorem ipsum dolor sit amet</NextStepsLink>
                         <NextStepsLink href="">Lorem ipsum dolor sit amet</NextStepsLink>
                         </div> */}
 
-                    <div className={aboutAuthor}>
-                        <h2>
-                            {post?.authors.length === 1
-                                ? hasAtLeastOneBio
-                                    ? 'About the author'
-                                    : 'Author'
-                                : hasAtLeastOneBio
-                                  ? 'About the authors'
-                                  : 'Authors'}
-                        </h2>
-                        {post?.authors?.map((author, index) => {
-                            const authorImage =
-                                author?.picture &&
-                                getImage(
-                                    author.picture.localFile.childImageSharp
-                                        .gatsbyImageData
-                                );
+                        <div className={aboutAuthor}>
+                            <h2>
+                                {post?.authors.length === 1
+                                    ? hasAtLeastOneBio
+                                        ? 'About the author'
+                                        : 'Author'
+                                    : hasAtLeastOneBio
+                                      ? 'About the authors'
+                                      : 'Authors'}
+                            </h2>
+                            {post?.authors?.map((author, index) => {
+                                const authorImage =
+                                    author?.picture &&
+                                    getImage(
+                                        author.picture.localFile.childImageSharp
+                                            .gatsbyImageData
+                                    );
 
-                            const authorBio = author?.bio.data.bio;
+                                const authorBio = author?.bio.data.bio;
 
-                            const authorSocialLinks = author?.socials;
+                                const authorSocialLinks = author?.socials;
 
-                            return (
-                                <>
-                                    <div key={index} className={authorInfo}>
-                                        <Link
-                                            to={getAuthorPathBySlug(
-                                                author?.slug
-                                            )}
-                                            className={authorMainInfoContainer}
-                                        >
-                                            <div
+                                return (
+                                    <>
+                                        <div key={index} className={authorInfo}>
+                                            <Link
+                                                to={getAuthorPathBySlug(
+                                                    author?.slug
+                                                )}
                                                 className={
-                                                    authorAvatarContainer
+                                                    authorMainInfoContainer
                                                 }
                                             >
-                                                <Avatar
-                                                    image={authorImage}
-                                                    alt={`Picture of ${author?.name}`}
-                                                    name={author.name}
-                                                    loading="lazy"
-                                                    size={60}
-                                                />
-                                            </div>
-                                            <div className={authorNameAndRole}>
-                                                {author?.name ? (
-                                                    <span
-                                                        className={authorName}
-                                                    >
-                                                        {author.name}
-                                                    </span>
-                                                ) : null}
-                                                {author?.role ? (
-                                                    <span
-                                                        className={authorRole}
-                                                    >
-                                                        {author.role}
-                                                    </span>
-                                                ) : null}
-                                            </div>
-                                        </Link>
-                                        {authorSocialLinks ? (
-                                            <>
-                                                <Divider
-                                                    orientation="vertical"
-                                                    variant="middle"
-                                                    flexItem
-                                                    sx={{
-                                                        minHeight: '57px',
-                                                        width: '1px',
-                                                        borderColor: '#d7dce5',
-                                                        margin: '0 30px 0 20px',
-                                                        [theme.breakpoints.down(
-                                                            520
-                                                        )]: {
-                                                            display: 'none',
-                                                        },
-                                                    }}
-                                                />
-                                                <SocialLinks
-                                                    socialLinks={
-                                                        authorSocialLinks
+                                                <div
+                                                    className={
+                                                        authorAvatarContainer
                                                     }
-                                                />
-                                            </>
+                                                >
+                                                    <Avatar
+                                                        image={authorImage}
+                                                        alt={`Picture of ${author?.name}`}
+                                                        name={author.name}
+                                                        loading="lazy"
+                                                        size={60}
+                                                    />
+                                                </div>
+                                                <div
+                                                    className={
+                                                        authorNameAndRole
+                                                    }
+                                                >
+                                                    {author?.name ? (
+                                                        <span
+                                                            className={
+                                                                authorName
+                                                            }
+                                                        >
+                                                            {author.name}
+                                                        </span>
+                                                    ) : null}
+                                                    {author?.role ? (
+                                                        <span
+                                                            className={
+                                                                authorRole
+                                                            }
+                                                        >
+                                                            {author.role}
+                                                        </span>
+                                                    ) : null}
+                                                </div>
+                                            </Link>
+                                            {authorSocialLinks ? (
+                                                <>
+                                                    <Divider
+                                                        orientation="vertical"
+                                                        variant="middle"
+                                                        flexItem
+                                                        sx={{
+                                                            minHeight: '57px',
+                                                            width: '1px',
+                                                            borderColor:
+                                                                '#d7dce5',
+                                                            margin: '0 30px 0 20px',
+                                                            [theme.breakpoints.down(
+                                                                520
+                                                            )]: {
+                                                                display: 'none',
+                                                            },
+                                                        }}
+                                                    />
+                                                    <SocialLinks
+                                                        socialLinks={
+                                                            authorSocialLinks
+                                                        }
+                                                    />
+                                                </>
+                                            ) : null}
+                                        </div>
+                                        {authorBio ? (
+                                            <div
+                                                dangerouslySetInnerHTML={{
+                                                    __html: author.bio.data.bio,
+                                                }}
+                                            />
                                         ) : null}
-                                    </div>
-                                    {authorBio ? (
-                                        <div
-                                            dangerouslySetInnerHTML={{
-                                                __html: author.bio.data.bio,
-                                            }}
-                                        />
-                                    ) : null}
-                                </>
-                            );
-                        })}
-                    </div>
-                </section>
+                                    </>
+                                );
+                            })}
+                        </div>
+                    </section>
+                ) : null}
                 <section className={popularArticlesWrapper}>
                     <h2>Popular Articles</h2>
                     <PopularArticles />

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -24,7 +24,11 @@ import Seo from '../../components/seo';
 import logoUrl from '../../images/combination-mark__multi-blue.png';
 import { costPerGB } from '../../utils';
 import ReadingTimeIcon from '../../svgs/time.svg';
-import { dashboardRegisterUrl, getAuthorPathBySlug } from '../../../shared';
+import {
+    dashboardRegisterUrl,
+    getAuthorPathBySlug,
+    getAuthorSeoJson,
+} from '../../../shared';
 import Avatar from '../../components/Avatar';
 import SocialLinks from '../../components/SocialLinks';
 import BlogBanner from '../../components/BlogBanner';
@@ -391,14 +395,9 @@ export const Head = ({
         },
     },
 }) => {
-    const mappedAuthors = post.authors.map((author) => ({
-        name: author.name,
-        url: author.link,
-        image: author.picture && {
-            '@type': 'ImageObject',
-            'url': `${siteUrl}/${author.picture.localFile.childImageSharp.fixedImg.gatsbyImageData}`,
-        },
-    }));
+    const mappedAuthors = post.authors.map((author) =>
+        getAuthorSeoJson(author, siteUrl)
+    );
 
     const postTags = post.tags
         .filter((tag) => tag.type === 'tag')


### PR DESCRIPTION
## Changes

https://github.com/estuary/marketing-site/issues/539
- Made a reusable SEO JSON generator so Blog and Author page can share logic
- Minor tweaks to queries

## Tests / Screenshots

### Blog post now includes full author details
![image](https://github.com/user-attachments/assets/6071fdbe-3cba-4cff-901c-5b6d311e2cbd)

### Author page shows the same deep details
![image](https://github.com/user-attachments/assets/59f7eca6-4732-49b3-8893-261a2035cddd)

