### PR TITLE
Update release banner text

### DIFF
--- a/src/components/Layout/ReleaseBanner/index.tsx
+++ b/src/components/Layout/ReleaseBanner/index.tsx
@@ -23,9 +23,8 @@ const ReleaseBanner = ({ theme = 'dark' }) => {
                 <a href="/deployment-options/" target="_blank" rel="noreferrer">
                     <span>A Step Ahead</span>
                     <p>
-                        Explore Estuary&apos;s powerful compliance solutions
-                        &#45; Streamline your security and scale with
-                        confidence!
+                        Private deployments are now live! Explore how Estuary
+                        Flow can fit into your environment.
                     </p>
                     <ArrowRight color="#fff" />
                 </a>


### PR DESCRIPTION
## Changes

-   Update release banner text to: "Private deployments are now live! Explore how Estuary can fit into your environment."

## Tests / Screenshots

- New text for the banner:

<img width="1361" alt="image" src="https://github.com/user-attachments/assets/f2cc20c1-85a7-4524-9eb9-ae31f7d52c81">

