### PR TITLE
Change Motherduck link from partners page

### DIFF
--- a/src/components/PartnersPage/JoinPartnerProgram/index.tsx
+++ b/src/components/PartnersPage/JoinPartnerProgram/index.tsx
@@ -37,7 +37,7 @@ const techPartners: Partner[] = [
             />
         ),
         name: 'MotherDuck',
-        href: 'http://motherduck.com/?utm_source=estuary&utm_medium=referral/',
+        href: 'https://motherduck.com/?utm_source=estuary&utm_medium=referral/',
     },
     {
         icon: (

--- a/src/components/PartnersPage/JoinPartnerProgram/index.tsx
+++ b/src/components/PartnersPage/JoinPartnerProgram/index.tsx
@@ -37,7 +37,7 @@ const techPartners: Partner[] = [
             />
         ),
         name: 'MotherDuck',
-        href: 'https://motherduck.com/ecosystem/estuary/',
+        href: 'http://motherduck.com/?utm_source=estuary&utm_medium=referral/',
     },
     {
         icon: (


### PR DESCRIPTION
## Changes

-   Change Motherduck link href on partners page to: http://motherduck.com/?utm_source=estuary&utm_medium=referral

## Tests / Screenshots

<img width="953" alt="image" src="https://github.com/user-attachments/assets/f2e2a2ce-6e9f-4367-8718-305579604751">

