### PR TITLE
Blog post images should lazy load

### DIFF
--- a/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
+++ b/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
-index 320309d..6d8129c 100644
+index 320309d..2a9fc55 100644
 --- a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 +++ b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 @@ -9,7 +9,7 @@ const {
@@ -48,7 +48,7 @@ index 320309d..6d8129c 100644
    formattedImgTag.classList = node.properties.className || []; // formattedImgTag.title = thisImg.attr(`title`)
    // formattedImgTag.alt = thisImg.attr(`alt`)
  
-@@ -153,50 +150,25 @@ const generateImagesAndUpdateNode = async function ({
+@@ -153,50 +150,24 @@ const generateImagesAndUpdateNode = async function ({
  
    try {
      await sharp(imageNode.absolutePath).metadata();
@@ -99,7 +99,6 @@ index 320309d..6d8129c 100644
 -      imgStyle: {
 -        opacity: 1
 -      }
-+      loading: "lazy",
      };
 -    if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width;
 -    const ReactImgEl = React.createElement(Img.default, imgOptions, null);

--- a/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
+++ b/patches/@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
-index 320309d..2a9fc55 100644
+index 320309d..6d8129c 100644
 --- a/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 +++ b/node_modules/@draftbox-co/gatsby-rehype-inline-images/gatsby-node.js
 @@ -9,7 +9,7 @@ const {
@@ -48,7 +48,7 @@ index 320309d..2a9fc55 100644
    formattedImgTag.classList = node.properties.className || []; // formattedImgTag.title = thisImg.attr(`title`)
    // formattedImgTag.alt = thisImg.attr(`alt`)
  
-@@ -153,50 +150,24 @@ const generateImagesAndUpdateNode = async function ({
+@@ -153,50 +150,25 @@ const generateImagesAndUpdateNode = async function ({
  
    try {
      await sharp(imageNode.absolutePath).metadata();
@@ -99,6 +99,7 @@ index 320309d..2a9fc55 100644
 -      imgStyle: {
 -        opacity: 1
 -      }
++      loading: "lazy",
      };
 -    if (formattedImgTag.width) imgOptions.style.width = formattedImgTag.width;
 -    const ReactImgEl = React.createElement(Img.default, imgOptions, null);

--- a/plugins/estuary-rehype-transformers/src/ImgSharp.jsx
+++ b/plugins/estuary-rehype-transformers/src/ImgSharp.jsx
@@ -1,6 +1,6 @@
 import { GatsbyImage } from 'gatsby-plugin-image';
 
-const ImgSharpInline = ({ className, imgdata, alt, loading }) => {
+const ImgSharpInline = ({ className, imgdata, alt }) => {
     const parsed = JSON.parse(imgdata);
     return (
         <GatsbyImage

--- a/plugins/estuary-rehype-transformers/src/ImgSharp.jsx
+++ b/plugins/estuary-rehype-transformers/src/ImgSharp.jsx
@@ -1,6 +1,6 @@
 import { GatsbyImage } from 'gatsby-plugin-image';
 
-const ImgSharpInline = ({ className, imgdata, alt }) => {
+const ImgSharpInline = ({ className, imgdata, alt, loading }) => {
     const parsed = JSON.parse(imgdata);
     return (
         <GatsbyImage
@@ -8,8 +8,6 @@ const ImgSharpInline = ({ className, imgdata, alt }) => {
             style={{ margin: '0 auto' }}
             image={parsed}
             alt={alt || 'Blog Post Image'}
-            loading="eager"
-            placeholder="none"
         />
     );
 };


### PR DESCRIPTION
## Changes

-   Set loading attribute of the images to lazy in the patch `@draftbox-co+gatsby-rehype-inline-images+1.0.2.patch`.
-   Remove loading eager from imgSharp.

## Tests / Screenshots

<img width="2116" alt="image" src="https://github.com/user-attachments/assets/c7c61501-1bdb-4059-92f0-9712fc3e8bfa">


Prod env:
<img width="2538" alt="image" src="https://github.com/user-attachments/assets/9f5facdb-34b8-42ba-940e-09b236406754">

Dev env:
<img width="2559" alt="image" src="https://github.com/user-attachments/assets/c3902bbf-b30d-4112-945c-e581f3b0b14a">