### PR TITLE
Add meta title and description from Strapi to Case Studies

### DIFF
--- a/src/layouts/CaseStudy/Head/index.tsx
+++ b/src/layouts/CaseStudy/Head/index.tsx
@@ -15,8 +15,8 @@ const CaseStudyHead = ({
     return (
         <>
             <Seo
-                title={caseStudy.Title}
-                description={caseStudy.Description ?? ''}
+                title={caseStudy.metaTitle}
+                description={caseStudy.metaDescription ?? ''}
                 url={`${siteUrl}/customers/${caseStudy.Slug}`}
                 image={
                     caseStudy.Logo

--- a/src/layouts/CaseStudy/Head/index.tsx
+++ b/src/layouts/CaseStudy/Head/index.tsx
@@ -16,7 +16,7 @@ const CaseStudyHead = ({
         <>
             <Seo
                 title={caseStudy.metaTitle}
-                description={caseStudy.metaDescription ?? ''}
+                description={caseStudy.metaDescription}
                 url={`${siteUrl}/customers/${caseStudy.Slug}`}
                 image={
                     caseStudy.Logo

--- a/src/layouts/CaseStudy/index.tsx
+++ b/src/layouts/CaseStudy/index.tsx
@@ -48,6 +48,8 @@ export const pageQuery = graphql`
         }
         caseStudy: strapiCaseStudy(id: { eq: $id }) {
             machineReadablePublishDate: publishedAt(formatString: "YYYY-MM-DD")
+            metaTitle
+            metaDescription
             Slug
             Title
             Description


### PR DESCRIPTION
#572

## Changes

-   Add metaTitle and metaDescription properties from Strapi to case studies SEO.