### PR TITLE
Change text "30 days free trial" from hero section

### DIFF
--- a/src/components/SubscriptionBenefits/index.tsx
+++ b/src/components/SubscriptionBenefits/index.tsx
@@ -18,7 +18,7 @@ const SubscriptionBenefits = () => {
                     <CheckmarkIcon width={14} color="#fff" />
                 </div>
                 <span>
-                    30 days <span>free trial</span>
+                    30-day <span>free trial</span>
                 </span>
             </li>
         </ul>


### PR DESCRIPTION
#587

## Changes

-   Fix text from 30 days to 30-day as requested by Sourabh.

## Tests / Screenshots

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/dfd4d4ef-89b2-4780-af6d-5e0920fef620">
