### PR TITLE
Fix deployment options section on mobile Safari

### DIFF
--- a/src/components/DeploymentOptions/DeploymentOptionDiagram/styles.module.less
+++ b/src/components/DeploymentOptions/DeploymentOptionDiagram/styles.module.less
@@ -2,9 +2,7 @@
 @secondaryTagColor: var(--blue);
 
 .container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: center;
+  display: flex;
   justify-content: center;
   gap: 20px;
   position: relative;
@@ -40,7 +38,10 @@
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  height: 100%;
+
+  .solidBorderBox {
+    height: 100%;
+  }
 
   @media (max-width: 600px) {
     gap: 10px;


### PR DESCRIPTION
#595 

## Changes

-   CSS Grid not working as expected on Safari in the deployment options section from the deployment options page and home page. Replacing with Flexbox solved the issue.

## Tests / Screenshots

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/72b65ed8-84ee-4347-97aa-1cb22e802c9e" />

