### PR TITLE
Remove see more button from success story navigation panel and update description

### DIFF
--- a/src/components/HeaderNavbar/CardItem/index.tsx
+++ b/src/components/HeaderNavbar/CardItem/index.tsx
@@ -47,6 +47,7 @@ const HeaderCardItem = ({
     onlyContent,
     active,
     contentFooterLink,
+    hasSeeMoreButton = false,
     ...props
 }: any) => {
     const [showAll, setShowAll] = React.useState(false);
@@ -65,7 +66,7 @@ const HeaderCardItem = ({
                 className={clsx(cardTitle, onlyContent ? hideOnMobile : null)}
             >
                 {title}
-                {items.length > 4 ? (
+                {hasSeeMoreButton && items.length > 4 ? (
                     <button
                         className={seeAllButton}
                         onClick={handleSeeAllButtonClick}

--- a/src/components/HeaderNavbar/Product/index.tsx
+++ b/src/components/HeaderNavbar/Product/index.tsx
@@ -54,6 +54,7 @@ const HeaderNavbarProduct = ({ active, setActive }) => {
                     <CardItem
                         title="COMPARE"
                         items={compare}
+                        hasSeeMoreButton
                         contentFooterLink={
                             <HeaderViewAllLink
                                 to="/etl-tools"

--- a/src/pages/success-stories/index.tsx
+++ b/src/pages/success-stories/index.tsx
@@ -50,7 +50,7 @@ export const Head = () => {
     return (
         <Seo
             title="Our Customers and Success Stories | Estuary Flow"
-            description="See how Estuary Flow solves complex data integration challenges for businesses around the world. Check out our success stories for proven success stories."
+            description="See how Estuary Flow solves complex data integration challenges for businesses around the world. Check out our proven success stories."
             image={metaImg.childImageSharp.gatsbyImageData.images.fallback.src}
         />
     );


### PR DESCRIPTION
#601 

## Changes

-  Make See More button optional in the header menu;
-  Remove See More button from the Success Stories in the header menu;
-   Update meta description of the success stories page.

## Tests / Screenshots

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/45911947-0b91-4ecb-8826-1e5ce8ba871d" />

