### PR TITLE
Comparison page improvement for seo

### DIFF
--- a/src/components/EtlToolsXvsYPage/Comparison/RelatedComparisonLinks/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/RelatedComparisonLinks/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import { getComparisonSlug, Vendor } from '../../../../../shared';
+import { container } from './styles.module.less';
+
+interface RelatedComparisonLinksProps {
+    vendors: Partial<Vendor>[];
+    excludeVendorIds: string[];
+    baseVendor: Vendor;
+}
+
+const RelatedComparisonLinks = ({
+    vendors,
+    excludeVendorIds,
+    baseVendor,
+}: RelatedComparisonLinksProps) => {
+    return (
+        <div className={container}>
+            {vendors
+                .filter(
+                    (vendor) =>
+                        vendor.id && !excludeVendorIds.includes(vendor.id)
+                )
+                .map((vendor) =>
+                    vendor.slugKey ? (
+                        <Link
+                            key={`related-comparison-link-${vendor.id}`}
+                            to={`/${getComparisonSlug(baseVendor.slugKey, vendor.slugKey)}`}
+                        >
+                            {baseVendor.name} vs {vendor.name}
+                        </Link>
+                    ) : null
+                )}
+        </div>
+    );
+};
+
+export default RelatedComparisonLinks;

--- a/src/components/EtlToolsXvsYPage/Comparison/RelatedComparisonLinks/styles.module.less
+++ b/src/components/EtlToolsXvsYPage/Comparison/RelatedComparisonLinks/styles.module.less
@@ -1,0 +1,19 @@
+.container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  margin-top: 20px;
+  row-gap: 8px;
+  column-gap: 24px;
+
+  a {
+    color: var(--blue);
+    font-weight: 500;
+    width: fit-content;
+
+    &:hover {
+      color: var(--blue);
+      text-underline-offset: 4px;
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -18,14 +18,28 @@ import Support from './Support';
 import Cost from './Cost';
 import VendorAvatar from './VendorAvatar';
 import IntroductoryDetails from './IntroductoryDetails';
+import RelatedComparisonLinks from './RelatedComparisonLinks';
 
 interface SectionTwoProps {
     xVendor: Vendor;
     yVendor: Vendor;
     estuaryVendor: Vendor;
+    allVendors: Partial<Vendor>[];
 }
 
-const articleBody = (xVendorName, yVendorName, estuaryVendorName) => ({
+const generateVendorRelatedComparisonsObject = (
+    vendorKey: string,
+    vendorName: string
+) => ({
+    id: `${vendorKey}-related-comparisons`,
+    heading: `Related comparisons to ${vendorName}`,
+});
+
+const articleBody = (
+    xVendorName: string,
+    yVendorName: string,
+    estuaryVendorName: string | null
+) => ({
     intro: {
         id: 'intro',
         heading: 'Introduction',
@@ -38,6 +52,14 @@ const articleBody = (xVendorName, yVendorName, estuaryVendorName) => ({
         id: 'how-to-choose',
         heading: 'How to choose the best option',
     },
+    xVendorRelatedComparisons: generateVendorRelatedComparisonsObject(
+        'x-vendor',
+        xVendorName
+    ),
+    yVendorRelatedComparisons: generateVendorRelatedComparisonsObject(
+        'y-vendor',
+        yVendorName
+    ),
 });
 
 const tableBodyComponents = [
@@ -51,12 +73,28 @@ const tableBodyComponents = [
     Cost,
 ];
 
-const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
+const Comparison = ({
+    xVendor,
+    yVendor,
+    estuaryVendor,
+    allVendors,
+}: SectionTwoProps) => {
     const isThreeVendorComparison = useMemo(() => {
         return ![xVendor.id, yVendor.id].includes(estuaryVendor.id);
     }, [xVendor.id, yVendor.id, estuaryVendor.id]);
 
-    const { intro, comparisonMatrix, howToChoose } = useMemo(
+    const excludeVendorIds = useMemo(
+        () => [xVendor.id, yVendor.id],
+        [xVendor.id, yVendor.id]
+    );
+
+    const {
+        intro,
+        comparisonMatrix,
+        howToChoose,
+        xVendorRelatedComparisons,
+        yVendorRelatedComparisons,
+    } = useMemo(
         () =>
             articleBody(
                 xVendor.name,
@@ -90,17 +128,25 @@ const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
             ],
         });
 
-        const vendors = [xVendor, yVendor].map(createVendorItem);
+        const comparedVendors = [xVendor, yVendor].map(createVendorItem);
 
         if (isThreeVendorComparison) {
-            vendors.unshift(createVendorItem(estuaryVendor));
+            comparedVendors.unshift(createVendorItem(estuaryVendor));
         }
 
         return [
             { id: intro.id, heading: intro.heading },
             { id: comparisonMatrix.id, heading: comparisonMatrix.heading },
-            ...vendors,
+            ...comparedVendors,
             { id: howToChoose.id, heading: howToChoose.heading },
+            {
+                id: xVendorRelatedComparisons.id,
+                heading: xVendorRelatedComparisons.heading,
+            },
+            {
+                id: yVendorRelatedComparisons.id,
+                heading: yVendorRelatedComparisons.heading,
+            },
         ];
     }, [
         xVendor,
@@ -110,6 +156,8 @@ const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
         intro,
         comparisonMatrix,
         howToChoose,
+        xVendorRelatedComparisons,
+        yVendorRelatedComparisons,
     ]);
 
     useEffect(() => {
@@ -272,6 +320,24 @@ const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
                         needs, and use this information to a good short-term and
                         long-term solution for you.
                     </p>
+
+                    <h2 id={xVendorRelatedComparisons.id}>
+                        {xVendorRelatedComparisons.heading}
+                    </h2>
+                    <RelatedComparisonLinks
+                        vendors={allVendors}
+                        baseVendor={xVendor}
+                        excludeVendorIds={excludeVendorIds}
+                    />
+
+                    <h2 id={yVendorRelatedComparisons.id}>
+                        {yVendorRelatedComparisons.heading}
+                    </h2>
+                    <RelatedComparisonLinks
+                        vendors={allVendors}
+                        baseVendor={yVendor}
+                        excludeVendorIds={excludeVendorIds}
+                    />
                 </div>
             </div>
         </section>

--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -25,22 +25,20 @@ interface SectionTwoProps {
     estuaryVendor: Vendor;
 }
 
-const articleBody = {
+const articleBody = (xVendorName, yVendorName, estuaryVendorName) => ({
     intro: {
         id: 'intro',
         heading: 'Introduction',
     },
     comparisonMatrix: {
         id: 'comparison-matrix',
-        heading: 'Comparison Matrix',
+        heading: `Comparison Matrix: ${xVendorName} vs ${yVendorName}${estuaryVendorName ? ` vs ${estuaryVendorName}` : ''}`,
     },
     howToChoose: {
         id: 'how-to-choose',
         heading: 'How to choose the best option',
     },
-};
-
-const { intro, comparisonMatrix, howToChoose } = articleBody;
+});
 
 const tableBodyComponents = [
     UseCases,
@@ -57,6 +55,16 @@ const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
     const isThreeVendorComparison = useMemo(() => {
         return ![xVendor.id, yVendor.id].includes(estuaryVendor.id);
     }, [xVendor.id, yVendor.id, estuaryVendor.id]);
+
+    const { intro, comparisonMatrix, howToChoose } = useMemo(
+        () =>
+            articleBody(
+                xVendor.name,
+                yVendor.name,
+                isThreeVendorComparison ? estuaryVendor.name : null
+            ),
+        [xVendor.name, yVendor.name, isThreeVendorComparison, estuaryVendor]
+    );
 
     const stickyRef1 = useRef<HTMLTableCellElement>(null);
     const stickyRef2 = useRef<HTMLTableCellElement>(null);
@@ -94,7 +102,15 @@ const Comparison = ({ xVendor, yVendor, estuaryVendor }: SectionTwoProps) => {
             ...vendors,
             { id: howToChoose.id, heading: howToChoose.heading },
         ];
-    }, [xVendor, yVendor, estuaryVendor, isThreeVendorComparison]);
+    }, [
+        xVendor,
+        yVendor,
+        estuaryVendor,
+        isThreeVendorComparison,
+        intro,
+        comparisonMatrix,
+        howToChoose,
+    ]);
 
     useEffect(() => {
         const handleScroll = () => {

--- a/src/templates/etl-tools/index.tsx
+++ b/src/templates/etl-tools/index.tsx
@@ -33,6 +33,11 @@ const EtlTools = ({
                 xVendor={xVendor}
                 yVendor={yVendor}
                 estuaryVendor={estuaryVendor}
+                allVendors={vendors.map((vendor) => ({
+                    id: vendor.id,
+                    name: vendor.name,
+                    slugKey: vendor.slugKey,
+                }))}
             />
             <GettingStarted />
         </Layout>


### PR DESCRIPTION
#600 

## Changes

-   Add the name of the two or three vendors in the "Comparison matrix" heading;
-   Add list of related comparison links for each vendor on the end of the article.

## Tests / Screenshots

-   2 vendors:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/1e5d692b-c12f-4038-a94c-158b7e461924" />

-   2 vendors vs Estuary:
<img width="627" alt="image" src="https://github.com/user-attachments/assets/a0340ea9-1b8d-4922-89ea-9cefd82bb76c" />

-   Related comparison links for each vendor in the end of the article:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/717a8ab1-f64b-4964-9794-7f031bd013ce" />
