### PR TITLE
Filter connectors removing the Dekaf connector

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -525,7 +525,9 @@ const cfg: GatsbyConfig = {
                 // containing properties to index. The objects must contain the `ref`
                 // field above (default: 'id'). This is required.
                 normalizer: ({ data }) =>
-                    data.postgres.allConnectors.nodes.map(normalizeConnector),
+                    data.postgres.allConnectors.nodes.flatMap(
+                        normalizeConnector
+                    ),
             },
         },
         {

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -525,9 +525,9 @@ const cfg: GatsbyConfig = {
                 // containing properties to index. The objects must contain the `ref`
                 // field above (default: 'id'). This is required.
                 normalizer: ({ data }) =>
-                    data.postgres.allConnectors.nodes.flatMap(
-                        normalizeConnector
-                    ),
+                    data.postgres.allConnectors.nodes
+                        .map(normalizeConnector)
+                        .filter((connector) => connector !== undefined),
             },
         },
         {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -346,7 +346,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
     const mapped_connectors =
         connectors.data?.postgres.allConnectors.nodes
             .filter((conn) => conn?.connectorTagsByConnectorIdList?.length > 0)
-            .map(normalizeConnector) ?? [];
+            .flatMap(normalizeConnector) ?? [];
 
     validateDataExistence(mapped_connectors, 'Connectors');
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -346,7 +346,8 @@ export const createPages: GatsbyNode['createPages'] = async ({
     const mapped_connectors =
         connectors.data?.postgres.allConnectors.nodes
             .filter((conn) => conn?.connectorTagsByConnectorIdList?.length > 0)
-            .flatMap(normalizeConnector) ?? [];
+            .map(normalizeConnector)
+            .filter((connector) => connector !== undefined) ?? [];
 
     validateDataExistence(mapped_connectors, 'Connectors');
 

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -162,7 +162,7 @@ export const Connectors = ({
                     (connector) =>
                         connector?.connectorTagsByConnectorIdList?.length > 0
                 )
-                .map(normalizeConnector)
+                .flatMap(normalizeConnector)
                 .filter((connector) =>
                     connectorType ? connector.type === connectorType : true
                 )

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -162,7 +162,8 @@ export const Connectors = ({
                     (connector) =>
                         connector?.connectorTagsByConnectorIdList?.length > 0
                 )
-                .flatMap(normalizeConnector)
+                .map(normalizeConnector)
+                .filter((connector) => connector !== undefined)
                 .filter((connector) =>
                     connectorType ? connector.type === connectorType : true
                 )

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -163,9 +163,12 @@ export const Connectors = ({
                         connector?.connectorTagsByConnectorIdList?.length > 0
                 )
                 .map(normalizeConnector)
-                .filter((connector) => connector !== undefined)
-                .filter((connector) =>
-                    connectorType ? connector.type === connectorType : true
+                .filter(
+                    (connector) =>
+                        connector !== undefined &&
+                        (connectorType
+                            ? connector.type === connectorType
+                            : true)
                 )
                 // eslint-disable-next-line array-callback-return
                 .sort((a, b) => {

--- a/src/components/ConnectorsLink/index.tsx
+++ b/src/components/ConnectorsLink/index.tsx
@@ -59,7 +59,7 @@ const ConnectorsLink = ({
                 (connector) =>
                     connector?.connectorTagsByConnectorIdList?.length > 0
             )
-            .map(normalizeConnector);
+            .flatMap(normalizeConnector);
 
         return [
             mapped.filter((connector) => connector.type === 'capture'),

--- a/src/components/ConnectorsLink/index.tsx
+++ b/src/components/ConnectorsLink/index.tsx
@@ -59,7 +59,8 @@ const ConnectorsLink = ({
                 (connector) =>
                     connector?.connectorTagsByConnectorIdList?.length > 0
             )
-            .flatMap(normalizeConnector);
+            .map(normalizeConnector)
+            .filter((connector) => connector !== undefined);
 
         return [
             mapped.filter((connector) => connector.type === 'capture'),

--- a/src/templates/etl-tools/index.tsx
+++ b/src/templates/etl-tools/index.tsx
@@ -1,4 +1,3 @@
-import { graphql } from 'gatsby';
 import Layout from '../../components/Layout';
 import Seo from '../../components/seo';
 import { Vendor } from '../../../shared';
@@ -54,735 +53,735 @@ export const Head = ({ data: { xVendor, yVendor } }) => {
 
 export default EtlTools;
 
-export const pageQuery = graphql`
-    query GetComparisons(
-        $xVendorId: String!
-        $yVendorId: String!
-        $estuaryVendorId: String!
-    ) {
-        xVendor: strapiComparison(id: { eq: $xVendorId }) {
-            id
-            name: Vendor_Name
-            logo {
-                localFile {
-                    childImageSharp {
-                        gatsbyImageData(placeholder: BLURRED)
-                    }
-                }
-            }
-            slugKey
-            useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                databaseReplication: Database_Replication
-                dataMigration: Data_Migration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                dataIntegration: Data_Integration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                aiPipelines: AI_Pipelines {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                operationalAnalytics: Operational_Analytics {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                streamProcessing: Stream_Processing {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            connectors: Connectors {
-                count: Count
-                streaming: Streaming
-                thirdParty: Third_Party {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            features: Features {
-                batchingStreaming: Batching_Streaming
-                deliveryGuarantee: Delivery_Guarantee
-                loadWhiteMethod: Load_Write_Method
-                dataOps: Data_Ops {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                eltTransforms: ELT_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                etlTransforms: ETL_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                schemaInference: Schema_Inference {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                storeReplay: Store_Replay {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                timeTravel: Time_Travel {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                snapshots: Snapshots {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                easeOfUse {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            deployment: Deployment {
-                options: Options
-                abilities: Abilities {
-                    perfMinLatency: Perf_Min_Latency
-                    reliability: Reliability
-                    scalability: Scalability
-                }
-                security: Security {
-                    dataSourceAuth: Data_Source_Auth
-                    encryption: Encryption
-                }
-            }
-            support: Support {
-                support: Support {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            cost: Cost {
-                vendor: Vendor {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                dataEngineering: Data_Engineering {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                admin: Admin {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            introductoryDetails {
-                introduction: Introduction {
-                    data {
-                        introduction: Introduction
-                    }
-                }
-                pros: Pros {
-                    data {
-                        pros: Pros
-                    }
-                }
-                cons: Cons {
-                    data {
-                        cons: Cons
-                    }
-                }
-                pricing: Pricing {
-                    data {
-                        pricing: Pricing
-                    }
-                }
-            }
-        }
-        yVendor: strapiComparison(id: { eq: $yVendorId }) {
-            id
-            name: Vendor_Name
-            logo {
-                localFile {
-                    childImageSharp {
-                        gatsbyImageData(placeholder: BLURRED)
-                    }
-                }
-            }
-            slugKey
-            useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                databaseReplication: Database_Replication
-                dataMigration: Data_Migration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                dataIntegration: Data_Integration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                aiPipelines: AI_Pipelines {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                operationalAnalytics: Operational_Analytics {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                streamProcessing: Stream_Processing {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            connectors: Connectors {
-                count: Count
-                streaming: Streaming
-                thirdParty: Third_Party {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            features: Features {
-                batchingStreaming: Batching_Streaming
-                deliveryGuarantee: Delivery_Guarantee
-                loadWhiteMethod: Load_Write_Method
-                dataOps: Data_Ops {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                eltTransforms: ELT_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                etlTransforms: ETL_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                schemaInference: Schema_Inference {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                storeReplay: Store_Replay {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                timeTravel: Time_Travel {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                snapshots: Snapshots {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                easeOfUse {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            deployment: Deployment {
-                options: Options
-                abilities: Abilities {
-                    perfMinLatency: Perf_Min_Latency
-                    reliability: Reliability
-                    scalability: Scalability
-                }
-                security: Security {
-                    dataSourceAuth: Data_Source_Auth
-                    encryption: Encryption
-                }
-            }
-            support: Support {
-                support: Support {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            cost: Cost {
-                vendor: Vendor {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                dataEngineering: Data_Engineering {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                admin: Admin {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            introductoryDetails {
-                introduction: Introduction {
-                    data {
-                        introduction: Introduction
-                    }
-                }
-                pros: Pros {
-                    data {
-                        pros: Pros
-                    }
-                }
-                cons: Cons {
-                    data {
-                        cons: Cons
-                    }
-                }
-                pricing: Pricing {
-                    data {
-                        pricing: Pricing
-                    }
-                }
-            }
-        }
-        estuaryVendor: strapiComparison(id: { eq: $estuaryVendorId }) {
-            id
-            name: Vendor_Name
-            logo {
-                localFile {
-                    childImageSharp {
-                        gatsbyImageData(placeholder: BLURRED)
-                    }
-                }
-            }
-            slugKey
-            useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                databaseReplication: Database_Replication
-                dataMigration: Data_Migration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                dataIntegration: Data_Integration {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                aiPipelines: AI_Pipelines {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                operationalAnalytics: Operational_Analytics {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                streamProcessing: Stream_Processing {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            connectors: Connectors {
-                count: Count
-                streaming: Streaming
-                thirdParty: Third_Party {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-            }
-            features: Features {
-                batchingStreaming: Batching_Streaming
-                deliveryGuarantee: Delivery_Guarantee
-                loadWhiteMethod: Load_Write_Method
-                dataOps: Data_Ops {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                eltTransforms: ELT_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                etlTransforms: ETL_Transforms {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                schemaInference: Schema_Inference {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                storeReplay: Store_Replay {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                timeTravel: Time_Travel {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                snapshots: Snapshots {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                easeOfUse {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            deployment: Deployment {
-                options: Options
-                abilities: Abilities {
-                    perfMinLatency: Perf_Min_Latency
-                    reliability: Reliability
-                    scalability: Scalability
-                }
-                security: Security {
-                    dataSourceAuth: Data_Source_Auth
-                    encryption: Encryption
-                }
-            }
-            support: Support {
-                support: Support {
-                    cellTitle
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            cost: Cost {
-                vendor: Vendor {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                dataEngineering: Data_Engineering {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-                admin: Admin {
-                    numberOfDollarSigns {
-                        array: strapi_json_value
-                    }
-                    subText {
-                        data {
-                            subText
-                        }
-                    }
-                }
-            }
-            introductoryDetails {
-                introduction: Introduction {
-                    data {
-                        introduction: Introduction
-                    }
-                }
-                pros: Pros {
-                    data {
-                        pros: Pros
-                    }
-                }
-                cons: Cons {
-                    data {
-                        cons: Cons
-                    }
-                }
-                pricing: Pricing {
-                    data {
-                        pricing: Pricing
-                    }
-                }
-            }
-        }
-        vendors: allStrapiComparison(
-            sort: { fields: Vendor_Name, order: ASC }
-        ) {
-            nodes {
-                id
-                name: Vendor_Name
-                logo {
-                    localFile {
-                        childImageSharp {
-                            gatsbyImageData(placeholder: BLURRED)
-                        }
-                    }
-                }
-                slugKey
-            }
-        }
-    }
-`;
+// export const pageQuery = graphql`
+//     query GetComparisons(
+//         $xVendorId: String!
+//         $yVendorId: String!
+//         $estuaryVendorId: String!
+//     ) {
+//         xVendor: strapiComparison(id: { eq: $xVendorId }) {
+//             id
+//             name: Vendor_Name
+//             logo {
+//                 localFile {
+//                     childImageSharp {
+//                         gatsbyImageData(placeholder: BLURRED)
+//                     }
+//                 }
+//             }
+//             slugKey
+//             useCases: UseCases {
+//                 odsReplication: ODS_Replication {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 databaseReplication: Database_Replication
+//                 dataMigration: Data_Migration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 dataIntegration: Data_Integration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 aiPipelines: AI_Pipelines {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 operationalAnalytics: Operational_Analytics {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 streamProcessing: Stream_Processing {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             connectors: Connectors {
+//                 count: Count
+//                 streaming: Streaming
+//                 thirdParty: Third_Party {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 customSdk: Custom_SDK {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 adminApi: Admin_API {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             features: Features {
+//                 batchingStreaming: Batching_Streaming
+//                 deliveryGuarantee: Delivery_Guarantee
+//                 loadWhiteMethod: Load_Write_Method
+//                 dataOps: Data_Ops {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 eltTransforms: ELT_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 etlTransforms: ETL_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 schemaInference: Schema_Inference {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 storeReplay: Store_Replay {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 timeTravel: Time_Travel {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 snapshots: Snapshots {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 easeOfUse {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             deployment: Deployment {
+//                 options: Options
+//                 abilities: Abilities {
+//                     perfMinLatency: Perf_Min_Latency
+//                     reliability: Reliability
+//                     scalability: Scalability
+//                 }
+//                 security: Security {
+//                     dataSourceAuth: Data_Source_Auth
+//                     encryption: Encryption
+//                 }
+//             }
+//             support: Support {
+//                 support: Support {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             cost: Cost {
+//                 vendor: Vendor {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 dataEngineering: Data_Engineering {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 admin: Admin {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             introductoryDetails {
+//                 introduction: Introduction {
+//                     data {
+//                         introduction: Introduction
+//                     }
+//                 }
+//                 pros: Pros {
+//                     data {
+//                         pros: Pros
+//                     }
+//                 }
+//                 cons: Cons {
+//                     data {
+//                         cons: Cons
+//                     }
+//                 }
+//                 pricing: Pricing {
+//                     data {
+//                         pricing: Pricing
+//                     }
+//                 }
+//             }
+//         }
+//         yVendor: strapiComparison(id: { eq: $yVendorId }) {
+//             id
+//             name: Vendor_Name
+//             logo {
+//                 localFile {
+//                     childImageSharp {
+//                         gatsbyImageData(placeholder: BLURRED)
+//                     }
+//                 }
+//             }
+//             slugKey
+//             useCases: UseCases {
+//                 odsReplication: ODS_Replication {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 databaseReplication: Database_Replication
+//                 dataMigration: Data_Migration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 dataIntegration: Data_Integration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 aiPipelines: AI_Pipelines {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 operationalAnalytics: Operational_Analytics {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 streamProcessing: Stream_Processing {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             connectors: Connectors {
+//                 count: Count
+//                 streaming: Streaming
+//                 thirdParty: Third_Party {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 customSdk: Custom_SDK {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 adminApi: Admin_API {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             features: Features {
+//                 batchingStreaming: Batching_Streaming
+//                 deliveryGuarantee: Delivery_Guarantee
+//                 loadWhiteMethod: Load_Write_Method
+//                 dataOps: Data_Ops {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 eltTransforms: ELT_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 etlTransforms: ETL_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 schemaInference: Schema_Inference {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 storeReplay: Store_Replay {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 timeTravel: Time_Travel {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 snapshots: Snapshots {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 easeOfUse {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             deployment: Deployment {
+//                 options: Options
+//                 abilities: Abilities {
+//                     perfMinLatency: Perf_Min_Latency
+//                     reliability: Reliability
+//                     scalability: Scalability
+//                 }
+//                 security: Security {
+//                     dataSourceAuth: Data_Source_Auth
+//                     encryption: Encryption
+//                 }
+//             }
+//             support: Support {
+//                 support: Support {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             cost: Cost {
+//                 vendor: Vendor {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 dataEngineering: Data_Engineering {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 admin: Admin {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             introductoryDetails {
+//                 introduction: Introduction {
+//                     data {
+//                         introduction: Introduction
+//                     }
+//                 }
+//                 pros: Pros {
+//                     data {
+//                         pros: Pros
+//                     }
+//                 }
+//                 cons: Cons {
+//                     data {
+//                         cons: Cons
+//                     }
+//                 }
+//                 pricing: Pricing {
+//                     data {
+//                         pricing: Pricing
+//                     }
+//                 }
+//             }
+//         }
+//         estuaryVendor: strapiComparison(id: { eq: $estuaryVendorId }) {
+//             id
+//             name: Vendor_Name
+//             logo {
+//                 localFile {
+//                     childImageSharp {
+//                         gatsbyImageData(placeholder: BLURRED)
+//                     }
+//                 }
+//             }
+//             slugKey
+//             useCases: UseCases {
+//                 odsReplication: ODS_Replication {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 databaseReplication: Database_Replication
+//                 dataMigration: Data_Migration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 dataIntegration: Data_Integration {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 aiPipelines: AI_Pipelines {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 operationalAnalytics: Operational_Analytics {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 streamProcessing: Stream_Processing {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             connectors: Connectors {
+//                 count: Count
+//                 streaming: Streaming
+//                 thirdParty: Third_Party {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 customSdk: Custom_SDK {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 adminApi: Admin_API {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//             }
+//             features: Features {
+//                 batchingStreaming: Batching_Streaming
+//                 deliveryGuarantee: Delivery_Guarantee
+//                 loadWhiteMethod: Load_Write_Method
+//                 dataOps: Data_Ops {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 eltTransforms: ELT_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 etlTransforms: ETL_Transforms {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 schemaInference: Schema_Inference {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 storeReplay: Store_Replay {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 timeTravel: Time_Travel {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 snapshots: Snapshots {
+//                     icon: Icon
+//                     subText: Sub_Text {
+//                         data {
+//                             subText: Sub_Text
+//                         }
+//                     }
+//                 }
+//                 easeOfUse {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             deployment: Deployment {
+//                 options: Options
+//                 abilities: Abilities {
+//                     perfMinLatency: Perf_Min_Latency
+//                     reliability: Reliability
+//                     scalability: Scalability
+//                 }
+//                 security: Security {
+//                     dataSourceAuth: Data_Source_Auth
+//                     encryption: Encryption
+//                 }
+//             }
+//             support: Support {
+//                 support: Support {
+//                     cellTitle
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             cost: Cost {
+//                 vendor: Vendor {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 dataEngineering: Data_Engineering {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//                 admin: Admin {
+//                     numberOfDollarSigns {
+//                         array: strapi_json_value
+//                     }
+//                     subText {
+//                         data {
+//                             subText
+//                         }
+//                     }
+//                 }
+//             }
+//             introductoryDetails {
+//                 introduction: Introduction {
+//                     data {
+//                         introduction: Introduction
+//                     }
+//                 }
+//                 pros: Pros {
+//                     data {
+//                         pros: Pros
+//                     }
+//                 }
+//                 cons: Cons {
+//                     data {
+//                         cons: Cons
+//                     }
+//                 }
+//                 pricing: Pricing {
+//                     data {
+//                         pricing: Pricing
+//                     }
+//                 }
+//             }
+//         }
+//         vendors: allStrapiComparison(
+//             sort: { fields: Vendor_Name, order: ASC }
+//         ) {
+//             nodes {
+//                 id
+//                 name: Vendor_Name
+//                 logo {
+//                     localFile {
+//                         childImageSharp {
+//                             gatsbyImageData(placeholder: BLURRED)
+//                         }
+//                     }
+//                 }
+//                 slugKey
+//             }
+//         }
+//     }
+// `;

--- a/src/templates/etl-tools/index.tsx
+++ b/src/templates/etl-tools/index.tsx
@@ -1,3 +1,4 @@
+import { graphql } from 'gatsby';
 import Layout from '../../components/Layout';
 import Seo from '../../components/seo';
 import { Vendor } from '../../../shared';
@@ -53,735 +54,735 @@ export const Head = ({ data: { xVendor, yVendor } }) => {
 
 export default EtlTools;
 
-// export const pageQuery = graphql`
-//     query GetComparisons(
-//         $xVendorId: String!
-//         $yVendorId: String!
-//         $estuaryVendorId: String!
-//     ) {
-//         xVendor: strapiComparison(id: { eq: $xVendorId }) {
-//             id
-//             name: Vendor_Name
-//             logo {
-//                 localFile {
-//                     childImageSharp {
-//                         gatsbyImageData(placeholder: BLURRED)
-//                     }
-//                 }
-//             }
-//             slugKey
-//             useCases: UseCases {
-//                 odsReplication: ODS_Replication {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 databaseReplication: Database_Replication
-//                 dataMigration: Data_Migration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 dataIntegration: Data_Integration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 aiPipelines: AI_Pipelines {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 operationalAnalytics: Operational_Analytics {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 streamProcessing: Stream_Processing {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             connectors: Connectors {
-//                 count: Count
-//                 streaming: Streaming
-//                 thirdParty: Third_Party {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 customSdk: Custom_SDK {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 adminApi: Admin_API {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             features: Features {
-//                 batchingStreaming: Batching_Streaming
-//                 deliveryGuarantee: Delivery_Guarantee
-//                 loadWhiteMethod: Load_Write_Method
-//                 dataOps: Data_Ops {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 eltTransforms: ELT_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 etlTransforms: ETL_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 schemaInference: Schema_Inference {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 storeReplay: Store_Replay {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 timeTravel: Time_Travel {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 snapshots: Snapshots {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 easeOfUse {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             deployment: Deployment {
-//                 options: Options
-//                 abilities: Abilities {
-//                     perfMinLatency: Perf_Min_Latency
-//                     reliability: Reliability
-//                     scalability: Scalability
-//                 }
-//                 security: Security {
-//                     dataSourceAuth: Data_Source_Auth
-//                     encryption: Encryption
-//                 }
-//             }
-//             support: Support {
-//                 support: Support {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             cost: Cost {
-//                 vendor: Vendor {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 dataEngineering: Data_Engineering {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 admin: Admin {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             introductoryDetails {
-//                 introduction: Introduction {
-//                     data {
-//                         introduction: Introduction
-//                     }
-//                 }
-//                 pros: Pros {
-//                     data {
-//                         pros: Pros
-//                     }
-//                 }
-//                 cons: Cons {
-//                     data {
-//                         cons: Cons
-//                     }
-//                 }
-//                 pricing: Pricing {
-//                     data {
-//                         pricing: Pricing
-//                     }
-//                 }
-//             }
-//         }
-//         yVendor: strapiComparison(id: { eq: $yVendorId }) {
-//             id
-//             name: Vendor_Name
-//             logo {
-//                 localFile {
-//                     childImageSharp {
-//                         gatsbyImageData(placeholder: BLURRED)
-//                     }
-//                 }
-//             }
-//             slugKey
-//             useCases: UseCases {
-//                 odsReplication: ODS_Replication {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 databaseReplication: Database_Replication
-//                 dataMigration: Data_Migration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 dataIntegration: Data_Integration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 aiPipelines: AI_Pipelines {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 operationalAnalytics: Operational_Analytics {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 streamProcessing: Stream_Processing {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             connectors: Connectors {
-//                 count: Count
-//                 streaming: Streaming
-//                 thirdParty: Third_Party {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 customSdk: Custom_SDK {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 adminApi: Admin_API {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             features: Features {
-//                 batchingStreaming: Batching_Streaming
-//                 deliveryGuarantee: Delivery_Guarantee
-//                 loadWhiteMethod: Load_Write_Method
-//                 dataOps: Data_Ops {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 eltTransforms: ELT_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 etlTransforms: ETL_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 schemaInference: Schema_Inference {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 storeReplay: Store_Replay {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 timeTravel: Time_Travel {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 snapshots: Snapshots {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 easeOfUse {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             deployment: Deployment {
-//                 options: Options
-//                 abilities: Abilities {
-//                     perfMinLatency: Perf_Min_Latency
-//                     reliability: Reliability
-//                     scalability: Scalability
-//                 }
-//                 security: Security {
-//                     dataSourceAuth: Data_Source_Auth
-//                     encryption: Encryption
-//                 }
-//             }
-//             support: Support {
-//                 support: Support {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             cost: Cost {
-//                 vendor: Vendor {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 dataEngineering: Data_Engineering {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 admin: Admin {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             introductoryDetails {
-//                 introduction: Introduction {
-//                     data {
-//                         introduction: Introduction
-//                     }
-//                 }
-//                 pros: Pros {
-//                     data {
-//                         pros: Pros
-//                     }
-//                 }
-//                 cons: Cons {
-//                     data {
-//                         cons: Cons
-//                     }
-//                 }
-//                 pricing: Pricing {
-//                     data {
-//                         pricing: Pricing
-//                     }
-//                 }
-//             }
-//         }
-//         estuaryVendor: strapiComparison(id: { eq: $estuaryVendorId }) {
-//             id
-//             name: Vendor_Name
-//             logo {
-//                 localFile {
-//                     childImageSharp {
-//                         gatsbyImageData(placeholder: BLURRED)
-//                     }
-//                 }
-//             }
-//             slugKey
-//             useCases: UseCases {
-//                 odsReplication: ODS_Replication {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 databaseReplication: Database_Replication
-//                 dataMigration: Data_Migration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 dataIntegration: Data_Integration {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 aiPipelines: AI_Pipelines {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 operationalAnalytics: Operational_Analytics {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 streamProcessing: Stream_Processing {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             connectors: Connectors {
-//                 count: Count
-//                 streaming: Streaming
-//                 thirdParty: Third_Party {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 customSdk: Custom_SDK {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 adminApi: Admin_API {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//             }
-//             features: Features {
-//                 batchingStreaming: Batching_Streaming
-//                 deliveryGuarantee: Delivery_Guarantee
-//                 loadWhiteMethod: Load_Write_Method
-//                 dataOps: Data_Ops {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 eltTransforms: ELT_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 etlTransforms: ETL_Transforms {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 schemaInference: Schema_Inference {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 storeReplay: Store_Replay {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 timeTravel: Time_Travel {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 snapshots: Snapshots {
-//                     icon: Icon
-//                     subText: Sub_Text {
-//                         data {
-//                             subText: Sub_Text
-//                         }
-//                     }
-//                 }
-//                 easeOfUse {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             deployment: Deployment {
-//                 options: Options
-//                 abilities: Abilities {
-//                     perfMinLatency: Perf_Min_Latency
-//                     reliability: Reliability
-//                     scalability: Scalability
-//                 }
-//                 security: Security {
-//                     dataSourceAuth: Data_Source_Auth
-//                     encryption: Encryption
-//                 }
-//             }
-//             support: Support {
-//                 support: Support {
-//                     cellTitle
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             cost: Cost {
-//                 vendor: Vendor {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 dataEngineering: Data_Engineering {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//                 admin: Admin {
-//                     numberOfDollarSigns {
-//                         array: strapi_json_value
-//                     }
-//                     subText {
-//                         data {
-//                             subText
-//                         }
-//                     }
-//                 }
-//             }
-//             introductoryDetails {
-//                 introduction: Introduction {
-//                     data {
-//                         introduction: Introduction
-//                     }
-//                 }
-//                 pros: Pros {
-//                     data {
-//                         pros: Pros
-//                     }
-//                 }
-//                 cons: Cons {
-//                     data {
-//                         cons: Cons
-//                     }
-//                 }
-//                 pricing: Pricing {
-//                     data {
-//                         pricing: Pricing
-//                     }
-//                 }
-//             }
-//         }
-//         vendors: allStrapiComparison(
-//             sort: { fields: Vendor_Name, order: ASC }
-//         ) {
-//             nodes {
-//                 id
-//                 name: Vendor_Name
-//                 logo {
-//                     localFile {
-//                         childImageSharp {
-//                             gatsbyImageData(placeholder: BLURRED)
-//                         }
-//                     }
-//                 }
-//                 slugKey
-//             }
-//         }
-//     }
-// `;
+export const pageQuery = graphql`
+    query GetComparisons(
+        $xVendorId: String!
+        $yVendorId: String!
+        $estuaryVendorId: String!
+    ) {
+        xVendor: strapiComparison(id: { eq: $xVendorId }) {
+            id
+            name: Vendor_Name
+            logo {
+                localFile {
+                    childImageSharp {
+                        gatsbyImageData(placeholder: BLURRED)
+                    }
+                }
+            }
+            slugKey
+            useCases: UseCases {
+                odsReplication: ODS_Replication {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                databaseReplication: Database_Replication
+                dataMigration: Data_Migration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                dataIntegration: Data_Integration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                aiPipelines: AI_Pipelines {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                operationalAnalytics: Operational_Analytics {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                streamProcessing: Stream_Processing {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            connectors: Connectors {
+                count: Count
+                streaming: Streaming
+                thirdParty: Third_Party {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                customSdk: Custom_SDK {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                adminApi: Admin_API {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            features: Features {
+                batchingStreaming: Batching_Streaming
+                deliveryGuarantee: Delivery_Guarantee
+                loadWhiteMethod: Load_Write_Method
+                dataOps: Data_Ops {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                eltTransforms: ELT_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                etlTransforms: ETL_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                schemaInference: Schema_Inference {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                storeReplay: Store_Replay {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                timeTravel: Time_Travel {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                snapshots: Snapshots {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                easeOfUse {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            deployment: Deployment {
+                options: Options
+                abilities: Abilities {
+                    perfMinLatency: Perf_Min_Latency
+                    reliability: Reliability
+                    scalability: Scalability
+                }
+                security: Security {
+                    dataSourceAuth: Data_Source_Auth
+                    encryption: Encryption
+                }
+            }
+            support: Support {
+                support: Support {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            cost: Cost {
+                vendor: Vendor {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                dataEngineering: Data_Engineering {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                admin: Admin {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            introductoryDetails {
+                introduction: Introduction {
+                    data {
+                        introduction: Introduction
+                    }
+                }
+                pros: Pros {
+                    data {
+                        pros: Pros
+                    }
+                }
+                cons: Cons {
+                    data {
+                        cons: Cons
+                    }
+                }
+                pricing: Pricing {
+                    data {
+                        pricing: Pricing
+                    }
+                }
+            }
+        }
+        yVendor: strapiComparison(id: { eq: $yVendorId }) {
+            id
+            name: Vendor_Name
+            logo {
+                localFile {
+                    childImageSharp {
+                        gatsbyImageData(placeholder: BLURRED)
+                    }
+                }
+            }
+            slugKey
+            useCases: UseCases {
+                odsReplication: ODS_Replication {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                databaseReplication: Database_Replication
+                dataMigration: Data_Migration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                dataIntegration: Data_Integration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                aiPipelines: AI_Pipelines {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                operationalAnalytics: Operational_Analytics {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                streamProcessing: Stream_Processing {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            connectors: Connectors {
+                count: Count
+                streaming: Streaming
+                thirdParty: Third_Party {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                customSdk: Custom_SDK {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                adminApi: Admin_API {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            features: Features {
+                batchingStreaming: Batching_Streaming
+                deliveryGuarantee: Delivery_Guarantee
+                loadWhiteMethod: Load_Write_Method
+                dataOps: Data_Ops {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                eltTransforms: ELT_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                etlTransforms: ETL_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                schemaInference: Schema_Inference {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                storeReplay: Store_Replay {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                timeTravel: Time_Travel {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                snapshots: Snapshots {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                easeOfUse {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            deployment: Deployment {
+                options: Options
+                abilities: Abilities {
+                    perfMinLatency: Perf_Min_Latency
+                    reliability: Reliability
+                    scalability: Scalability
+                }
+                security: Security {
+                    dataSourceAuth: Data_Source_Auth
+                    encryption: Encryption
+                }
+            }
+            support: Support {
+                support: Support {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            cost: Cost {
+                vendor: Vendor {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                dataEngineering: Data_Engineering {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                admin: Admin {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            introductoryDetails {
+                introduction: Introduction {
+                    data {
+                        introduction: Introduction
+                    }
+                }
+                pros: Pros {
+                    data {
+                        pros: Pros
+                    }
+                }
+                cons: Cons {
+                    data {
+                        cons: Cons
+                    }
+                }
+                pricing: Pricing {
+                    data {
+                        pricing: Pricing
+                    }
+                }
+            }
+        }
+        estuaryVendor: strapiComparison(id: { eq: $estuaryVendorId }) {
+            id
+            name: Vendor_Name
+            logo {
+                localFile {
+                    childImageSharp {
+                        gatsbyImageData(placeholder: BLURRED)
+                    }
+                }
+            }
+            slugKey
+            useCases: UseCases {
+                odsReplication: ODS_Replication {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                databaseReplication: Database_Replication
+                dataMigration: Data_Migration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                dataIntegration: Data_Integration {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                aiPipelines: AI_Pipelines {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                operationalAnalytics: Operational_Analytics {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                streamProcessing: Stream_Processing {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            connectors: Connectors {
+                count: Count
+                streaming: Streaming
+                thirdParty: Third_Party {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                customSdk: Custom_SDK {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                adminApi: Admin_API {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+            }
+            features: Features {
+                batchingStreaming: Batching_Streaming
+                deliveryGuarantee: Delivery_Guarantee
+                loadWhiteMethod: Load_Write_Method
+                dataOps: Data_Ops {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                eltTransforms: ELT_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                etlTransforms: ETL_Transforms {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                schemaInference: Schema_Inference {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                storeReplay: Store_Replay {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                timeTravel: Time_Travel {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                snapshots: Snapshots {
+                    icon: Icon
+                    subText: Sub_Text {
+                        data {
+                            subText: Sub_Text
+                        }
+                    }
+                }
+                easeOfUse {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            deployment: Deployment {
+                options: Options
+                abilities: Abilities {
+                    perfMinLatency: Perf_Min_Latency
+                    reliability: Reliability
+                    scalability: Scalability
+                }
+                security: Security {
+                    dataSourceAuth: Data_Source_Auth
+                    encryption: Encryption
+                }
+            }
+            support: Support {
+                support: Support {
+                    cellTitle
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            cost: Cost {
+                vendor: Vendor {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                dataEngineering: Data_Engineering {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+                admin: Admin {
+                    numberOfDollarSigns {
+                        array: strapi_json_value
+                    }
+                    subText {
+                        data {
+                            subText
+                        }
+                    }
+                }
+            }
+            introductoryDetails {
+                introduction: Introduction {
+                    data {
+                        introduction: Introduction
+                    }
+                }
+                pros: Pros {
+                    data {
+                        pros: Pros
+                    }
+                }
+                cons: Cons {
+                    data {
+                        cons: Cons
+                    }
+                }
+                pricing: Pricing {
+                    data {
+                        pricing: Pricing
+                    }
+                }
+            }
+        }
+        vendors: allStrapiComparison(
+            sort: { fields: Vendor_Name, order: ASC }
+        ) {
+            nodes {
+                id
+                name: Vendor_Name
+                logo {
+                    localFile {
+                        childImageSharp {
+                            gatsbyImageData(placeholder: BLURRED)
+                        }
+                    }
+                }
+                slugKey
+            }
+        }
+    }
+`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ const CONNECTOR_IMAGE_RE = /(source|materialize)-([a-z0-9\-]+)/;
 export const normalizeConnector = (connector: any) => {
     if (connector.imageName === 'ghcr.io/estuary/dekaf-generic') {
         // Exclude Dekaf connector through the imageName because the id might change periodically.
-        return [];
+        return undefined;
     }
     if (!connector) {
         return connector;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,8 +12,8 @@ import {
 const CONNECTOR_IMAGE_RE = /(source|materialize)-([a-z0-9\-]+)/;
 
 export const normalizeConnector = (connector: any) => {
-    if (connector.id === '0f:df:77:d9:d8:77:bc:00') {
-        // Exclude Dekaf connector
+    if (connector.imageName === 'ghcr.io/estuary/dekaf-generic') {
+        // Exclude Dekaf connector through the imageName because the id might change periodically.
         return [];
     }
     if (!connector) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,10 @@ import {
 const CONNECTOR_IMAGE_RE = /(source|materialize)-([a-z0-9\-]+)/;
 
 export const normalizeConnector = (connector: any) => {
+    if (connector.id === '0f:df:77:d9:d8:77:bc:00') {
+        // Exclude Dekaf connector
+        return [];
+    }
     if (!connector) {
         return connector;
     }


### PR DESCRIPTION
#628

## Changes

-   Filter the connectors removing the Dekaf connector.

It was not possible to filter connectors removing Dekaf through GraphQL queries, so it was done through the `normalizeConnector` function reaching all the function instances.
