### PR TITLE
Rename/remove several comparison matrix fields

### DIFF
--- a/shared.ts
+++ b/shared.ts
@@ -124,7 +124,6 @@ export interface Vendor {
     logo: any;
     slugKey: string;
     useCases: {
-        odsReplication: HasFeature;
         databaseReplication: string;
         dataMigration: HasFeature;
         dataIntegration: HasFeature;
@@ -137,7 +136,6 @@ export interface Vendor {
         streaming: string;
         thirdParty: HasFeature;
         customSdk: HasFeature;
-        adminApi: HasFeature;
     };
     features: {
         batchingStreaming: string;

--- a/src/components/EtlToolsXvsYPage/Comparison/Connectors/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/Connectors/index.tsx
@@ -4,9 +4,8 @@ import TableRows from '../TableRows';
 const rows = [
     { label: 'Number of connectors', key: 'count' },
     { label: 'Streaming connectors', key: 'streaming' },
-    { label: 'Support for 3rd party connectors', key: 'thirdParty' },
+    { label: '3rd party connectors', key: 'thirdParty' },
     { label: 'Custom SDK', key: 'customSdk' },
-    { label: 'API (for admin)', key: 'adminApi' },
 ];
 
 const Connectors = ({ xVendor, yVendor, estuaryVendor }: ComparisonVendors) => {

--- a/src/components/EtlToolsXvsYPage/Comparison/CoreFeatures/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/CoreFeatures/index.tsx
@@ -4,10 +4,10 @@ import TableRows from '../TableRows';
 const rows = [
     { label: 'Batch and streaming', key: 'batchingStreaming' },
     { label: 'Delivery guarantee', key: 'deliveryGuarantee' },
-    { label: 'Load write method', key: 'loadWhiteMethod' },
-    { label: 'DataOps support', key: 'dataOps' },
     { label: 'ELT transforms', key: 'eltTransforms' },
     { label: 'ETL transforms', key: 'etlTransforms' },
+    { label: 'Load write method', key: 'loadWhiteMethod' },
+    { label: 'DataOps support', key: 'dataOps' },
     { label: 'Schema inference and drift', key: 'schemaInference' },
     { label: 'Store and replay', key: 'storeReplay' },
     { label: 'Time travel', key: 'timeTravel' },

--- a/src/components/EtlToolsXvsYPage/Comparison/Security/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/Security/index.tsx
@@ -2,7 +2,7 @@ import { ComparisonVendors } from '../shared';
 import TableRows from '../TableRows';
 
 const rows = [
-    { label: 'Data Source Authentication', key: 'dataSourceAuth' },
+    { label: 'Data source authentication', key: 'dataSourceAuth' },
     { label: 'Encryption', key: 'encryption' },
 ];
 

--- a/src/components/EtlToolsXvsYPage/Comparison/TheAbilities/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/TheAbilities/index.tsx
@@ -14,7 +14,7 @@ const TheAbilities = ({
 }: ComparisonVendors) => {
     return (
         <TableRows
-            title="The abilities"
+            title="Abilities"
             rows={rows}
             xVendor={xVendor}
             yVendor={yVendor}

--- a/src/components/EtlToolsXvsYPage/Comparison/UseCases/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/UseCases/index.tsx
@@ -3,15 +3,14 @@ import TableRows from '../TableRows';
 
 const rows = [
     {
-        label: 'Database replication (CDC) - sources',
+        label: 'Database replication (CDC)',
         key: 'databaseReplication',
     },
-    { label: 'Replication to ODS', key: 'odsReplication' },
-    { label: 'Op. data integration', key: 'dataIntegration' },
+    { label: 'Operational integration', key: 'dataIntegration' },
     { label: 'Data migration', key: 'dataMigration' },
     { label: 'Stream processing', key: 'streamProcessing' },
-    { label: 'Operational Analytics', key: 'operationalAnalytics' },
-    { label: 'AI Pipelines', key: 'aiPipelines' },
+    { label: 'Operational analytics', key: 'operationalAnalytics' },
+    { label: 'AI pipelines', key: 'aiPipelines' },
 ];
 
 const UseCases = ({ xVendor, yVendor, estuaryVendor }: ComparisonVendors) => {

--- a/src/templates/etl-tools/index.tsx
+++ b/src/templates/etl-tools/index.tsx
@@ -72,14 +72,6 @@ export const pageQuery = graphql`
             }
             slugKey
             useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 databaseReplication: Database_Replication
                 dataMigration: Data_Migration {
                     icon: Icon
@@ -134,14 +126,6 @@ export const pageQuery = graphql`
                     }
                 }
                 customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
                     icon: Icon
                     subText: Sub_Text {
                         data {
@@ -308,14 +292,6 @@ export const pageQuery = graphql`
             }
             slugKey
             useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 databaseReplication: Database_Replication
                 dataMigration: Data_Migration {
                     icon: Icon
@@ -370,14 +346,6 @@ export const pageQuery = graphql`
                     }
                 }
                 customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
                     icon: Icon
                     subText: Sub_Text {
                         data {
@@ -544,14 +512,6 @@ export const pageQuery = graphql`
             }
             slugKey
             useCases: UseCases {
-                odsReplication: ODS_Replication {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
                 databaseReplication: Database_Replication
                 dataMigration: Data_Migration {
                     icon: Icon
@@ -606,14 +566,6 @@ export const pageQuery = graphql`
                     }
                 }
                 customSdk: Custom_SDK {
-                    icon: Icon
-                    subText: Sub_Text {
-                        data {
-                            subText: Sub_Text
-                        }
-                    }
-                }
-                adminApi: Admin_API {
                     icon: Icon
                     subText: Sub_Text {
                         data {


### PR DESCRIPTION
## Changes

We’d like to make some updates to streamline our comparison matrix. This PR provides a bit of initial setup for that, removing a few fields and renaming others. It looks like more drastic changes, such as adding fields or moving them between sections, will require Strapi admin work to update the underlying API.

## Tests / Screenshots

-   Confirmed that the updated matrix layout appeared as expected. For example, compare the current use case fields:

<img width="1217" alt="old_matrix" src="https://github.com/user-attachments/assets/b7d87948-35b1-4b83-ad43-ce4c7bb723c1" />

With the updated version (no ODS Replication row; updated field labels):

<img width="1239" alt="new_matrix" src="https://github.com/user-attachments/assets/e4ee729a-0d21-4b44-9de1-1c5511286cb1" />

