### PR TITLE
CODEOWNERS: Add mdanko for privacy notice

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+src/pages/privacy-policy.tsx @skord


### PR DESCRIPTION
Since we're working on the privacy criteria for
SOC2 and GDPR, we need to make sure that any
changes in the privacy notice are reviewed by
the security officer and are synced to Drata.

This will clear the way for:
- https://github.com/estuary/ops/issues/655
- https://github.com/estuary/ops/issues/650
- https://github.com/estuary/ops/issues/651
- https://github.com/estuary/ops/issues/652
- https://github.com/estuary/ops/issues/653