### PR TITLE
Show homepage second section on first viewport

### DIFF
--- a/src/components/Homepage/Hero/styles.module.less
+++ b/src/components/Homepage/Hero/styles.module.less
@@ -26,6 +26,7 @@
     .sectionTopBottomPadding;
 
     padding-top: 16px;
+    padding-bottom: 40px;
     display: flex;
     flex-direction: column;
     background-color: var(--dark-blue);

--- a/src/components/Homepage/MoveAndTransform/styles.module.less
+++ b/src/components/Homepage/MoveAndTransform/styles.module.less
@@ -4,6 +4,7 @@
     .globalMaxWidth;
     .sectionTopBottomPadding;
 
+    padding-top: 40px;
     display: flex;
     flex-direction: column;
     gap: 40px;
@@ -19,12 +20,11 @@
     }
 
     h2 {
-        font-size: 2.5rem;
+        font-size: 2.25rem;
         font-weight: 600;
         line-height: 48px;
         text-align: center;
         text-transform: uppercase;
-        margin: 0 48px;
         color: var(--grey);
 
         @media (max-width: 810px) {

--- a/src/components/Homepage/MoveAndTransform/styles.module.less
+++ b/src/components/Homepage/MoveAndTransform/styles.module.less
@@ -4,7 +4,7 @@
     .globalMaxWidth;
     .sectionTopBottomPadding;
 
-    padding-top: 40px;
+    padding-top: 60px;
     display: flex;
     flex-direction: column;
     gap: 40px;


### PR DESCRIPTION
#665

## Changes

-   Change the vertical paddings of the hero and second sections from homepage.

## Tests / Screenshots

Less spacing below the carousel of customers' logo and above the second section's title:
<img width="1611" alt="image" src="https://github.com/user-attachments/assets/df361702-d61f-414c-b622-8fee8b337932" />

