### PR TITLE
Remove full uppercase from blog post and success story titles

### DIFF
--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -59,6 +59,7 @@
 
   p {
     color: var(--grey);
+    margin-bottom: 16px;
   }
 }
 

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -54,7 +54,7 @@
   h1 {
     margin-top: 36px;
     color: var(--grey);
-    text-transform: uppercase;
+    text-transform: none;
   }
 
   p {

--- a/src/templates/success-story/styles.module.less
+++ b/src/templates/success-story/styles.module.less
@@ -15,6 +15,7 @@
 
     h1 {
         color: var(--grey);
+        text-transform: none
     }
 }
 


### PR DESCRIPTION
## Changes

-   Remove uppercase from blog post and success story template titles;
-   Add missing margin to author's avatar from hero section of the blog post.

## Tests / Screenshots

<img width="804" alt="image" src="https://github.com/user-attachments/assets/a61414ed-049e-47c3-9ee6-efce960ccf3a" />

<img width="805" alt="image" src="https://github.com/user-attachments/assets/8aef3645-1a35-4faf-9ed6-ef6c40ea3952" />