### PR TITLE
adding an initial setting for report only CSP

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -522,6 +522,10 @@
                     {
                         "key": "Strict-Transport-Security",
                         "value": "\"max-age=31536000; includeSubDomains\" always"
+                    },
+                    {
+                        "key": "Content-Security-Policy-Report-Only",
+                        "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
                     }
                 ]
             },


### PR DESCRIPTION
## Changes

https://github.com/estuary/security/issues/217

- Adding a report only CSP header that is totally wide open but something so we can start seeing the impact

## Tests / Screenshots

- N/A
