### PR TITLE
Fix: Remove flex display from paragraphs

### DIFF
--- a/src/templates/success-story/styles.module.less
+++ b/src/templates/success-story/styles.module.less
@@ -185,7 +185,6 @@
 
         p {
             line-height: 30px;
-            display: flex;
             justify-content: center;
         }
     }


### PR DESCRIPTION
## Changes

-   Paragraphs in case studies are treating components like links as separate columns when using Flex display. Removing this styling displays paragraphs more normally, with in-line links.

## Tests / Screenshots

Tested locally to confirm. Currently, paragraphs in case studies look like this when they contain links:
<img width="1182" alt="de_link_columns" src="https://github.com/user-attachments/assets/413dbe87-2be8-40af-90b1-9d2e3925f789" />

With this fix, they will now appear as:
<img width="1159" alt="de_link_fixed" src="https://github.com/user-attachments/assets/3e7e16e6-6fe7-4388-aac4-e10619083141" />
