### PR TITLE
Fix pricing calculator responsiveness

### DIFF
--- a/src/components/PricingCalculator/styles.module.less
+++ b/src/components/PricingCalculator/styles.module.less
@@ -134,8 +134,8 @@
     width: 100%;
     flex-wrap: wrap;
 
-    @media (max-width: 525px) {
-        gap: 4px;
+    @media (max-width: 425px) {
+        gap: 12px;
         max-width: 100%;
     }
 }
@@ -156,8 +156,6 @@
     font-weight: 400;
     line-height: 24px;
     display: inline-block;
-    white-space: nowrap;
-    text-align: center;
 
     span {
         color: var(--dark-blue);
@@ -172,6 +170,11 @@
     display: flex;
     align-items: center;
     gap: 24px;
+
+    @media (max-width: 320px) {
+        flex-direction: column;
+        gap: 12px;
+    }
 }
 
 .detail {


### PR DESCRIPTION
#709 

## Changes

-   Added some CSS to adjust the pricing calculator responsiveness on mobile.

## Tests / Screenshots

Tested locally, we are good to merge without preview:
<img width="155" alt="image" src="https://github.com/user-attachments/assets/f197db37-737a-44a8-855f-044fe9c775ba" />

