### PR TITLE
Fix social preview image from success story page

### DIFF
--- a/src/templates/success-story/Head/index.tsx
+++ b/src/templates/success-story/Head/index.tsx
@@ -17,7 +17,7 @@ const SuccessStoryHead = ({
                 url={`${siteUrl}/success-stories/${successStory.Slug}`}
                 image={
                     successStory.Logo
-                        ? `${siteUrl}${successStory.Logo.localFile.childImageSharp.meta_img.gatsbyImageData}`
+                        ? `${siteUrl}${successStory.Logo.localFile.childImageSharp.metaImg.images.fallback.src}`
                         : undefined
                 }
             />
@@ -33,7 +33,7 @@ const SuccessStoryHead = ({
                     'description': successStory.Description ?? '',
                     'image':
                         successStory.Logo &&
-                        `${siteUrl}${successStory.Logo.localFile.childImageSharp.meta_img.src}`,
+                        `${siteUrl}${successStory.Logo.localFile.childImageSharp.metaImg.images.fallback.src}`,
                     'publisher': {
                         '@type': 'Organization',
                         'name': 'Estuary',

--- a/src/templates/success-story/index.tsx
+++ b/src/templates/success-story/index.tsx
@@ -51,7 +51,11 @@ export const pageQuery = graphql`
                             placeholder: BLURRED
                             formats: [AUTO, WEBP, AVIF]
                         )
-                        metaImg: gatsbyImageData(layout: FIXED, width: 500)
+                        metaImg: gatsbyImageData(
+                            layout: FIXED
+                            width: 1200
+                            height: 630
+                        )
                     }
                 }
             }

--- a/src/templates/success-story/index.tsx
+++ b/src/templates/success-story/index.tsx
@@ -51,7 +51,7 @@ export const pageQuery = graphql`
                             placeholder: BLURRED
                             formats: [AUTO, WEBP, AVIF]
                         )
-                        meta_img: gatsbyImageData(layout: FIXED, width: 500)
+                        metaImg: gatsbyImageData(layout: FIXED, width: 500)
                     }
                 }
             }


### PR DESCRIPTION
#713 

 Open graph image from success story pages not being displayed.
 
## Changes
-   Use the right property from the fetched meta image.