### PR TITLE
Fix success stories displaying 404 from all success stories page

### DIFF
--- a/src/components/BlogPopularArticles/index.tsx
+++ b/src/components/BlogPopularArticles/index.tsx
@@ -67,8 +67,12 @@ export const PopularArticles = () => {
 
     return (
         <Grid>
-            {popularArticles?.nodes?.map((article: any) => (
-                <Card key={article.id} data={article} footerTag="Article" />
+            {popularArticles?.nodes?.map(({ id, slug, ...rest }: any) => (
+                <Card
+                    key={id}
+                    data={{ ...rest, id, slug: `/blog/${slug}` }}
+                    footerTag="Article"
+                />
             ))}
         </Grid>
     );

--- a/src/components/EtlToolsPage/LearnMoreArticles/index.tsx
+++ b/src/components/EtlToolsPage/LearnMoreArticles/index.tsx
@@ -4,6 +4,8 @@ import Container from '../../Container';
 import { cardsWrapper } from './styles.module.less';
 import Card from './Card';
 
+const slugPrefix = '/blog';
+
 const LearnMoreArticles = () => {
     return (
         <section className={defaultWrapperGrey}>
@@ -12,15 +14,15 @@ const LearnMoreArticles = () => {
                 <div className={cardsWrapper}>
                     <Card
                         title="The Data Engineer's Guide to ELT Alternatives"
-                        buttonHref="/ELT-alternatives-guide/"
+                        buttonHref={`${slugPrefix}/ELT-alternatives-guide/`}
                     />
                     <Card
                         title="The Data Engineer's Guide to ETL Alternatives"
-                        buttonHref="/ETL-alternatives-guide/"
+                        buttonHref={`${slugPrefix}/ETL-alternatives-guide/`}
                     />
                     <Card
                         title="The Data Engineer's Guide to CDC for Analytics, Ops, and AI Pipelines"
-                        buttonHref="/CDC-comparison-guide/"
+                        buttonHref={`${slugPrefix}/CDC-comparison-guide/`}
                     />
                 </div>
             </Container>

--- a/src/components/Grid/Card/index.tsx
+++ b/src/components/Grid/Card/index.tsx
@@ -133,7 +133,7 @@ const Card = ({ data, footerTag, hasImgBackground = false }: CardProps) => {
 
     return (
         <li key={data.id}>
-            <Link to={`/blog/${data.slug}`} className={container}>
+            <Link to={data.slug} className={container}>
                 {hasImgBackground ? (
                     <div className={imgWrapper}>
                         <GatsbyImage {...imageProps} />

--- a/src/components/SuccessStoriesPage/SuccessStories/index.tsx
+++ b/src/components/SuccessStoriesPage/SuccessStories/index.tsx
@@ -36,11 +36,6 @@ const SuccessStories = () => {
         }
     `);
 
-    const successStoriesWithPrefixedSlugs = successStories.map((post) => ({
-        ...post,
-        slug: `success-stories/${post.slug}/`,
-    }));
-
     const [visiblePosts, setVisiblePosts] = useState(9);
 
     const handleShowMore = () => {
@@ -52,7 +47,7 @@ const SuccessStories = () => {
             <Container isVertical>
                 <h2 className={sectionTitle}>SUCCESS STORIES</h2>
                 <Grid>
-                    {successStoriesWithPrefixedSlugs
+                    {successStories
                         .slice(0, visiblePosts)
                         .map((successStory) => (
                             <Card
@@ -63,7 +58,7 @@ const SuccessStories = () => {
                             />
                         ))}
                 </Grid>
-                {visiblePosts < successStoriesWithPrefixedSlugs.length ? (
+                {visiblePosts < successStories.length ? (
                     <ButtonFilled onClick={handleShowMore}>
                         Show more
                     </ButtonFilled>

--- a/src/templates/author/SectionTwo/index.tsx
+++ b/src/templates/author/SectionTwo/index.tsx
@@ -29,13 +29,15 @@ const SectionTwo = ({ author: { name, blogPosts } }: SectionTwoProps) => {
                 CONTENT FROM <span>{name}</span>
             </h2>
             <Grid>
-                {blogPosts.slice(0, visiblePosts).map((blogPost) => (
-                    <Card
-                        key={blogPost.id}
-                        data={blogPost}
-                        footerTag="Article"
-                    />
-                ))}
+                {blogPosts
+                    .slice(0, visiblePosts)
+                    .map(({ id, slug, ...rest }) => (
+                        <Card
+                            key={id}
+                            data={{ ...rest, id, slug: `/blog/${slug}` }}
+                            footerTag="Article"
+                        />
+                    ))}
             </Grid>
             {visiblePosts < blogPosts.length ? (
                 <ButtonFilled onClick={handleShowMore}>Show more</ButtonFilled>


### PR DESCRIPTION
#724

## Changes

-   Remove `/blog` from some slugs;
-   Add the same prefix to three blog posts from the all comparisons page.

## Tests / Screenshots

<img width="842" alt="image" src="https://github.com/user-attachments/assets/0d6a0e08-28b6-49c3-9518-ebe53e5ca911" />

<img width="939" alt="image" src="https://github.com/user-attachments/assets/fcb3ea67-d65d-417f-886e-d061ddb07639" />

<img width="905" alt="image" src="https://github.com/user-attachments/assets/f9af9cc3-c5b7-487f-989f-a9589b2050e8" />

<img width="906" alt="image" src="https://github.com/user-attachments/assets/61c04794-02ef-461f-bf0a-dfc6247dfef7" />

<img width="910" alt="image" src="https://github.com/user-attachments/assets/f403b8b0-8eee-4466-a70a-2424a935609a" />

