### PR TITLE
Add Ecommerce to Industry Solutions in Navbar

### DIFF
--- a/src/components/HeaderNavbar/Solutions/items.tsx
+++ b/src/components/HeaderNavbar/Solutions/items.tsx
@@ -71,6 +71,13 @@ export const industrySolutionItems: MenuCardItem[] = [
         Image: () => <AdaptedPieChartIcon />,
         linkId: getMenuLinkId('marketing'),
     },
+    {
+        name: 'Ecommerce',
+        to: `${urlPrefix}/industry/ecommerce-data-integration/`,
+        description: '',
+        Image: () => <AdaptedPieChartIcon />,
+        linkId: getMenuLinkId('ecommerce'),
+    },
 ];
 
 export const technologySolutionItems: MenuCardItem[] = [


### PR DESCRIPTION
## Changes

Adds the new [Ecommerce solutions page](https://estuary.dev/solutions/industry/ecommerce-data-integration/) to the navbar list of industry solutions.

Closes issue #729 

## Tests / Screenshots

Tested locally to confirm that the Ecommerce page was accessible via the navbar.

<img width="1359" alt="ecomm-solutions-page" src="https://github.com/user-attachments/assets/63773932-6b12-4faf-aa66-27c78af1471c" />
