### PR TITLE
Add Healthcare to Industry Solutions in Navigation Menu

### DIFF
--- a/src/components/HeaderNavbar/CardItem/index.tsx
+++ b/src/components/HeaderNavbar/CardItem/index.tsx
@@ -66,7 +66,7 @@ const HeaderCardItem = ({
     active,
     contentFooterLink,
     hasSeeMoreButton = false,
-    maxNumberOfLinks = 4,
+    maxNumberOfLinks = 5,
     ...props
 }: HeaderCardItemProps) => {
     const [showAll, setShowAll] = useState(false);

--- a/src/components/HeaderNavbar/Solutions/items.tsx
+++ b/src/components/HeaderNavbar/Solutions/items.tsx
@@ -78,6 +78,13 @@ export const industrySolutionItems: MenuCardItem[] = [
         Image: () => <AdaptedPieChartIcon />,
         linkId: getMenuLinkId('ecommerce'),
     },
+    {
+        name: 'Healthcare & wellness',
+        to: `${urlPrefix}/industry/healthcare-data-integration/`,
+        description: '',
+        Image: () => <AdaptedPieChartIcon />,
+        linkId: getMenuLinkId('healthcare'),
+    },
 ];
 
 export const technologySolutionItems: MenuCardItem[] = [


### PR DESCRIPTION
## Changes

One more solution page for now: this adds the new [Healthcare solutions page](https://estuary.dev/solutions/industry/healthcare-data-integration/) to the Industry section of the Solutions menu.

Since this exceeded the max number of links for a `CardItem`, I increased that property, but am open to other solutions, such as a "See all" page.

Thanks for reviewing!

Closes issue #734 

## Tests / Screenshots

Tested locally to confirm that the Healthcare page was accessible via the navigation menu. Checked that other menus in the header navbar were not affected by the change.

<img width="1349" alt="healthcare-solutions-page" src="https://github.com/user-attachments/assets/100bc52c-27c1-47a1-9af6-574d1deff52c" />

