### PR TITLE
Fix list element marks cut off in blog post body

### DIFF
--- a/src/components/ArticleSidebar/styles.module.less
+++ b/src/components/ArticleSidebar/styles.module.less
@@ -1,12 +1,12 @@
 .container {
   display: flex;
   flex-direction: column;
-  max-width: 256px;
+  min-width: 256px;
   width: 100%;
   gap: 24px;
   height: fit-content;
 
-  @media (max-width: 1150px) {
+  @media (max-width: 1024px) {
     max-width: 100%;
   }
 
@@ -25,7 +25,7 @@
 .shareArticleDesktop {
   display: flex;
 
-  @media (max-width: 1150px) {
+  @media (max-width: 1024px) {
     display: none;
   }
 }
@@ -33,7 +33,7 @@
 .tableOfContentsWrapper {
   overflow: auto;
 
-  @media (max-width: 1150px) {
+  @media (max-width: 1024px) {
     margin-bottom: 32px;
   }
 }

--- a/src/components/EtlToolsXvsYPage/Comparison/styles.module.less
+++ b/src/components/EtlToolsXvsYPage/Comparison/styles.module.less
@@ -51,7 +51,7 @@
 
     thead th:not(:first-of-type) {
       position: sticky;
-      top: 116px;
+      top: 80px;
       padding: 0;
     }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { Link } from 'gatsby';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Slide, useMediaQuery } from '@mui/material';
+import { Slide } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import ColoredLogo from '../../svgs/colored-logo.svg';
 import GithubIcon from '../../svgs/github-outline.svg';
@@ -34,6 +34,8 @@ import {
     globalHeaderMobileMenuWrapper,
     globalHeaderMobileMenuButton,
     headerSocialIcon,
+    menuContentDesktop,
+    menuContentMobile,
 } from './styles.module.less';
 
 const slideTimeout = 150;
@@ -41,8 +43,6 @@ const slideTimeout = 150;
 const Header = () => {
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
     const [activeMenu, setActiveMenu] = useState<string | null>(null);
-
-    const isMobile = useMediaQuery('(max-width:1142px)');
 
     const wrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -74,14 +74,12 @@ const Header = () => {
         };
     }, [mobileMenuOpen]);
 
-    const menuContent = useMemo(
+    const headerNavbar = useMemo(
         () => (
-            <div className={globalHeaderLinkWrapper}>
-                <HeaderNavbar
-                    activeMenu={activeMenu}
-                    setActiveMenu={setActiveMenu}
-                />
-            </div>
+            <HeaderNavbar
+                activeMenu={activeMenu}
+                setActiveMenu={setActiveMenu}
+            />
         ),
         [activeMenu, setActiveMenu]
     );
@@ -104,20 +102,31 @@ const Header = () => {
                         <strong className={globalHeaderTitle}>Estuary</strong>
                     </Link>
                     <div className={globalHeaderWrapper}>
-                        {isMobile ? (
-                            <Slide
-                                direction="left"
-                                in={mobileMenuOpen || !!activeMenu}
-                                timeout={{
-                                    enter: slideTimeout,
-                                    exit: slideTimeout,
-                                }}
+                        <Slide
+                            direction="left"
+                            in={mobileMenuOpen}
+                            timeout={{
+                                enter: slideTimeout,
+                                exit: slideTimeout,
+                            }}
+                        >
+                            <div
+                                className={clsx(
+                                    globalHeaderLinkWrapper,
+                                    menuContentMobile
+                                )}
                             >
-                                {menuContent}
-                            </Slide>
-                        ) : (
-                            menuContent
-                        )}
+                                {headerNavbar}
+                            </div>
+                        </Slide>
+                        <div
+                            className={clsx(
+                                globalHeaderLinkWrapper,
+                                menuContentDesktop
+                            )}
+                        >
+                            {headerNavbar}
+                        </div>
                         <div className={headerSocialIcons}>
                             <OutboundLink
                                 id="slack-header-link"

--- a/src/components/Header/styles.module.less
+++ b/src/components/Header/styles.module.less
@@ -154,3 +154,15 @@
     display: none;
   }
 }
+
+.menuContentDesktop {
+  @media (max-width: @menuTransitionMaxWidthBreakpoint) {
+    display: none;
+  }
+}
+
+.menuContentMobile {
+  @media (min-width: @menuTransitionMinWidthBreakpoint) {
+    display: none;
+  }
+}

--- a/src/components/ShareArticle/styles.module.less
+++ b/src/components/ShareArticle/styles.module.less
@@ -9,18 +9,10 @@
       line-height: 30px;
       color: var(--dark-blue);
   }
-
-  @media (max-width: 1150px) {
-      margin-bottom: 0;
-  }
 }
 
 .socialButtonsWrapper {
   display: flex;
   gap: 14px;
   flex-wrap: wrap;
-
-  @media (max-width: 1150px) {
-      gap: 20px;
-  }
 }

--- a/src/components/styles.module.less
+++ b/src/components/styles.module.less
@@ -73,7 +73,7 @@
     background-color: var(--light-blue);
   }
 
-  @media (max-width: 1150px) {
+  @media (max-width: 1024px) {
     width: 48px;
     height: 48px;
   }

--- a/src/style.less
+++ b/src/style.less
@@ -260,23 +260,18 @@ span {
 }
 
 .dynamic-html {
-    width: 100%;
-    overflow: hidden;
-
     .table {
         overflow-x: auto;
+        margin-left: 0;
+        margin-right: 0;
+        width: 100% !important;
 
-        @media (max-width: 620px) {
-            float: none !important;
-            width: 100% !important;
-            margin: 0;
+        table {
+            min-width: 900px;
         }
 
-        &>table {
-            width: 100%;
-            min-width: 400px;
-            margin-top: 0;
-            margin-bottom: 0;
+        @media (max-width: 768px) {
+            float: none !important;
         }
     }
 }


### PR DESCRIPTION
#716

## Changes

-   Fix list element markers cut off on blog post body;

I fixed this bug but leveraged this PR to solve other bugs as well:
-   Fix blog post table not scrolling as expected;
-   Fix comparison table header with extra spacing on the top;
-   Fix blog post sidebar's wrong width on the comparison page;
-   Fix mobile and desktop menus conflict - both were opening on first page load on mobile.

## Tests / Screenshots

Now the list item markers are being totally displayed:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/7d210797-b73f-43c2-95f7-8c10d714558d" />

Another bug - off topic:
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/ef38c531-382c-40fa-82a4-1434518dc250" />
Fixed:
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/95c6d283-e103-4428-81e5-bd9a1e6ec5df" />