### PR TITLE
Reverse sort order success stories on homepage and success stories page

### DIFF
--- a/shared.ts
+++ b/shared.ts
@@ -206,3 +206,23 @@ const getVendorLinkId = (vendorName?: string) => getSlugifiedText(vendorName);
 
 export const getVendorsLinkId = (vendorName1?: string, vendorName2?: string) =>
     `${getVendorLinkId(vendorName1)}-vs-${getVendorLinkId(vendorName2)}`;
+
+export const getSortedSuccessStories = (successStories) => {
+    const priorityOrder = ['forward', 'headset', 'prodege'];
+
+    const sortedSuccessStories = [...successStories].sort((a, b) => {
+        const indexA = priorityOrder.findIndex((keyword) =>
+            a.slug.includes(keyword)
+        );
+        const indexB = priorityOrder.findIndex((keyword) =>
+            b.slug.includes(keyword)
+        );
+
+        if (indexA === -1 && indexB === -1) return 0;
+        if (indexA === -1) return 1;
+        if (indexB === -1) return -1;
+        return indexA - indexB;
+    });
+
+    return sortedSuccessStories;
+};

--- a/shared.ts
+++ b/shared.ts
@@ -207,22 +207,22 @@ const getVendorLinkId = (vendorName?: string) => getSlugifiedText(vendorName);
 export const getVendorsLinkId = (vendorName1?: string, vendorName2?: string) =>
     `${getVendorLinkId(vendorName1)}-vs-${getVendorLinkId(vendorName2)}`;
 
+const successStoriesPriorityOrder = ['forward', 'headset', 'prodege'];
+
+const sortSuccessStoriesByPriority = (a, b) => {
+    const indexA = successStoriesPriorityOrder.findIndex((keyword) =>
+        a.slug.includes(keyword)
+    );
+    const indexB = successStoriesPriorityOrder.findIndex((keyword) =>
+        b.slug.includes(keyword)
+    );
+
+    if (indexA === -1 && indexB === -1) return 0;
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+};
+
 export const getSortedSuccessStories = (successStories) => {
-    const priorityOrder = ['forward', 'headset', 'prodege'];
-
-    const sortedSuccessStories = [...successStories].sort((a, b) => {
-        const indexA = priorityOrder.findIndex((keyword) =>
-            a.slug.includes(keyword)
-        );
-        const indexB = priorityOrder.findIndex((keyword) =>
-            b.slug.includes(keyword)
-        );
-
-        if (indexA === -1 && indexB === -1) return 0;
-        if (indexA === -1) return 1;
-        if (indexB === -1) return -1;
-        return indexA - indexB;
-    });
-
-    return sortedSuccessStories;
+    return successStories.sort(sortSuccessStoriesByPriority);
 };

--- a/src/components/Homepage/SuccessStories/index.tsx
+++ b/src/components/Homepage/SuccessStories/index.tsx
@@ -3,6 +3,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import DarkSwoopingLinesLeftDirectionBackground from '../../BackgroundImages/DarkSwoopingLinesLeftDirectionBackground';
 import Container from '../../Container';
 import SlideDeckCarousel from '../../SlideDeckCarousel';
+import { getSortedSuccessStories } from '../../../../shared';
 import Card from './Card';
 import { container } from './styles.module.less';
 
@@ -11,7 +12,7 @@ const SuccessStories = () => {
         allStrapiCaseStudy: { nodes: allSuccessStories },
     } = useStaticQuery(graphql`
         query GetAllHomepageSuccessStories {
-            allStrapiCaseStudy(limit: 10) {
+            allStrapiCaseStudy(sort: { fields: [createdAt], order: DESC }) {
                 nodes {
                     description: Description
                     title: Title
@@ -29,12 +30,14 @@ const SuccessStories = () => {
         }
     `);
 
+    const sortedSuccessStories = getSortedSuccessStories(allSuccessStories);
+
     return (
         <DarkSwoopingLinesLeftDirectionBackground>
             <Container isVertical className={container}>
                 <h2>SUCCESS STORIES</h2>
                 <SlideDeckCarousel
-                    items={allSuccessStories}
+                    items={sortedSuccessStories}
                     itemsPerSlide={3}
                     ariaLabel="Success stories carousel"
                     renderCard={({ id, title, description, slug, logo }) => (

--- a/src/components/SuccessStoriesPage/SuccessStories/index.tsx
+++ b/src/components/SuccessStoriesPage/SuccessStories/index.tsx
@@ -6,7 +6,7 @@ import Grid from '../../Grid';
 import Card from '../../Grid/Card';
 import ButtonFilled from '../../LinksAndButtons/ButtonFilled';
 import { sectionTitle } from '../styles.module.less';
-import { getSlugifiedText } from '../../../../shared';
+import { getSlugifiedText, getSortedSuccessStories } from '../../../../shared';
 
 const SuccessStories = () => {
     const {
@@ -37,21 +37,7 @@ const SuccessStories = () => {
         }
     `);
 
-    const priorityOrder = ['forward', 'headset', 'prodege'];
-
-    const sortedSuccessStories = [...successStories].sort((a, b) => {
-        const indexA = priorityOrder.findIndex((keyword) =>
-            a.slug.includes(keyword)
-        );
-        const indexB = priorityOrder.findIndex((keyword) =>
-            b.slug.includes(keyword)
-        );
-
-        if (indexA === -1 && indexB === -1) return 0;
-        if (indexA === -1) return 1;
-        if (indexB === -1) return -1;
-        return indexA - indexB;
-    });
+    const sortedSuccessStories = getSortedSuccessStories(successStories);
 
     const [visiblePostsAmount, setVisiblePostsAmount] = useState(9);
 

--- a/src/components/SuccessStoriesPage/SuccessStories/index.tsx
+++ b/src/components/SuccessStoriesPage/SuccessStories/index.tsx
@@ -13,7 +13,7 @@ const SuccessStories = () => {
         allStrapiCaseStudy: { nodes: successStories },
     } = useStaticQuery(graphql`
         query GetSuccessStories {
-            allStrapiCaseStudy {
+            allStrapiCaseStudy(sort: { fields: [createdAt], order: DESC }) {
                 nodes {
                     title: Title
                     description: Description
@@ -37,10 +37,28 @@ const SuccessStories = () => {
         }
     `);
 
-    const [visiblePosts, setVisiblePosts] = useState(9);
+    const priorityOrder = ['forward', 'headset', 'prodege'];
+
+    const sortedSuccessStories = [...successStories].sort((a, b) => {
+        const indexA = priorityOrder.findIndex((keyword) =>
+            a.slug.includes(keyword)
+        );
+        const indexB = priorityOrder.findIndex((keyword) =>
+            b.slug.includes(keyword)
+        );
+
+        if (indexA === -1 && indexB === -1) return 0;
+        if (indexA === -1) return 1;
+        if (indexB === -1) return -1;
+        return indexA - indexB;
+    });
+
+    const [visiblePostsAmount, setVisiblePostsAmount] = useState(9);
 
     const handleShowMore = () => {
-        setVisiblePosts((prevVisiblePosts) => prevVisiblePosts + 9);
+        setVisiblePostsAmount(
+            (prevVisiblePostsAmount) => prevVisiblePostsAmount + 9
+        );
     };
 
     return (
@@ -48,8 +66,8 @@ const SuccessStories = () => {
             <Container isVertical>
                 <h2 className={sectionTitle}>SUCCESS STORIES</h2>
                 <Grid>
-                    {successStories
-                        .slice(0, visiblePosts)
+                    {sortedSuccessStories
+                        .slice(0, visiblePostsAmount)
                         .map((successStory) => (
                             <Card
                                 key={successStory.id}
@@ -60,7 +78,7 @@ const SuccessStories = () => {
                             />
                         ))}
                 </Grid>
-                {visiblePosts < successStories.length ? (
+                {visiblePostsAmount < successStories.length ? (
                     <ButtonFilled onClick={handleShowMore}>
                         Show more
                     </ButtonFilled>


### PR DESCRIPTION
#739 #732 

## Changes

-   Reverse sort order success stories on homepage and success stories page;
-   Remove limit of the homepage success stories so that the Headset success stories shows up;
-   Sort by createdAt descendent;
-   Add forward, headset and prodege as first success stories. 

## Tests / Screenshots

Homepage:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/3865850d-359e-4569-82b4-e2ebfc998e81" />

All success stories page:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/42aae884-70a6-4d84-8cc2-9ffc3e93976a" />