### PR TITLE
Centralize horizontally the blog post images

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -284,6 +284,8 @@ span {
     .gatsby-image-wrapper,
     .raw-html-embed {
         display: flex !important;
+        flex-direction: column;
+        align-items: center;
         justify-content: center;
         width: fit-content;
         margin-left: auto;

--- a/src/style.less
+++ b/src/style.less
@@ -280,12 +280,19 @@ span {
         }
     }
 
-    figure, .gatsby-image-wrapper, .raw-html-embed {
+    figure,
+    .gatsby-image-wrapper,
+    .raw-html-embed {
         display: flex !important;
         justify-content: center;
         width: fit-content;
         margin-left: auto;
         margin-right: auto;
+    }
+
+    .gatsby-image-wrapper {
+        margin-top: 32px !important;
+        margin-bottom: 32px !important;
     }
 }
 

--- a/src/style.less
+++ b/src/style.less
@@ -280,7 +280,7 @@ span {
         }
     }
 
-    figure, .gatsby-image-wrapper {
+    figure, .gatsby-image-wrapper, .raw-html-embed {
         display: flex !important;
         justify-content: center;
         width: fit-content;

--- a/src/style.less
+++ b/src/style.less
@@ -280,7 +280,7 @@ span {
         }
     }
 
-    figure,
+    figure.image,
     .gatsby-image-wrapper,
     .raw-html-embed {
         display: flex !important;

--- a/src/style.less
+++ b/src/style.less
@@ -279,6 +279,14 @@ span {
             margin-bottom: 0;
         }
     }
+
+    figure, .gatsby-image-wrapper {
+        display: flex !important;
+        justify-content: center;
+        width: fit-content;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 table td,


### PR DESCRIPTION
#733 

## Changes

-   Centralize horizontally the blog post images.

## Tests / Screenshots

Examples:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/70139208-b85b-457e-a5db-36a95cb8eb6a" />

<img width="788" alt="image" src="https://github.com/user-attachments/assets/94629917-773a-4e16-9646-1a764d462237" />

