### PR TITLE
Adjust comparison text on vendor pricing heading

### DIFF
--- a/src/components/EtlToolsXvsYPage/Comparison/IntroductoryDetails/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/IntroductoryDetails/index.tsx
@@ -32,7 +32,7 @@ const VendorDetails = ({ vendor }: { vendor: Vendor }) => {
                     __html: vendor.introductoryDetails.cons.data.cons,
                 }}
             />
-            <h3 id={`${vendorId}-pricing`}>Pricing</h3>
+            <h3 id={`${vendorId}-pricing`}>{vendor.name} Pricing</h3>
             <div
                 dangerouslySetInnerHTML={{
                     __html: vendor.introductoryDetails.pricing.data.pricing,

--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -125,7 +125,7 @@ const Comparison = ({
                 },
                 {
                     id: `${vendor.name.replace(' ', '-')}-pricing`,
-                    heading: 'Pricing',
+                    heading: `${vendor.name} Pricing`,
                 },
             ],
         });


### PR DESCRIPTION
#744

## Changes

-   Add the vendor name into the vendor pricing heading from the vendor details sections.

## Tests / Screenshots

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/8fb0b04c-50aa-499c-abd4-fde56919236c" />


