### PR TITLE
Add success story banner to the comparison page

### DIFF
--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -219,7 +219,10 @@ const Comparison = ({
                         best option for you based on your current and future
                         needs.
                     </p>
-                    <SuccessStoryBanner pageId="comparison-page" />
+                    {xVendor.slugKey === 'airbyte' &&
+                    yVendor.slugKey === 'estuary' ? (
+                        <SuccessStoryBanner pageId="comparison-page" />
+                    ) : null}
                     <h2 id={comparisonMatrix.id}>{comparisonMatrix.heading}</h2>
                     <table
                         className={

--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -7,6 +7,7 @@ import {
 import { defaultWrapperGrey } from '../../../globalStyles/wrappers.module.less';
 import BlogBanner from '../../BlogBanner';
 import ArticleSidebar from '../../ArticleSidebar';
+import SuccessStoryBanner from '../../SuccessStoryBanner';
 import {
     container,
     rightColumn,
@@ -218,6 +219,7 @@ const Comparison = ({
                         best option for you based on your current and future
                         needs.
                     </p>
+                    <SuccessStoryBanner pageId="comparison-page" />
                     <h2 id={comparisonMatrix.id}>{comparisonMatrix.heading}</h2>
                     <table
                         className={

--- a/src/components/EtlToolsXvsYPage/Comparison/index.tsx
+++ b/src/components/EtlToolsXvsYPage/Comparison/index.tsx
@@ -219,8 +219,7 @@ const Comparison = ({
                         best option for you based on your current and future
                         needs.
                     </p>
-                    {xVendor.slugKey === 'airbyte' &&
-                    yVendor.slugKey === 'estuary' ? (
+                    {[xVendor.slugKey, yVendor.slugKey].includes('airbyte') ? (
                         <SuccessStoryBanner pageId="comparison-page" />
                     ) : null}
                     <h2 id={comparisonMatrix.id}>{comparisonMatrix.heading}</h2>

--- a/src/components/Layout/ReleaseBanner/styles.module.less
+++ b/src/components/Layout/ReleaseBanner/styles.module.less
@@ -13,8 +13,8 @@
       align-items: center;
       justify-content: space-between;
       gap: 32px;
-      background-color: #FFA80040;
-      border: 1px solid #FFA800CC;
+      background-color: var(--banner-background-color);
+      border: 1px solid var(--banner-border-color);
       border-radius: 12px;
       padding: 16px 24px;
       width: 100%;
@@ -22,7 +22,7 @@
       transition: var(--default-transition);
 
       &:hover {
-        background-color: #FFA80050;
+        background-color: var(--banner-hover-background-color);
       }
 
       span {

--- a/src/components/SuccessStoryBanner/index.tsx
+++ b/src/components/SuccessStoryBanner/index.tsx
@@ -1,0 +1,69 @@
+import clsx from 'clsx';
+import { GatsbyImage } from 'gatsby-plugin-image';
+import { graphql, useStaticQuery } from 'gatsby';
+import LinkFilled from '../LinksAndButtons/LinkFilled';
+import {
+    container,
+    darkBackgroundColor,
+    imageWrapper,
+} from './styles.module.less';
+
+interface SuccessStoryBannerProps {
+    theme?: 'dark' | 'light';
+    pageId: string;
+}
+
+const SuccessStoryBanner = ({
+    theme = 'light',
+    pageId,
+}: SuccessStoryBannerProps) => {
+    const { successStory } = useStaticQuery(graphql`
+        query GetBannerSuccessStory {
+            successStory: strapiCaseStudy(Slug: { eq: "headset" }) {
+                slug: Slug
+                title: Title
+                description: Description
+                logo: Logo {
+                    localFile {
+                        childImageSharp {
+                            gatsbyImageData(
+                                layout: CONSTRAINED
+                                placeholder: BLURRED
+                                quality: 100
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    `);
+
+    return (
+        <div
+            className={clsx(
+                container,
+                theme === 'dark' ? darkBackgroundColor : null
+            )}
+        >
+            <div className={imageWrapper}>
+                <GatsbyImage
+                    alt={`${successStory.title} logo`}
+                    image={
+                        successStory.logo.localFile.childImageSharp
+                            .gatsbyImageData
+                    }
+                />
+            </div>
+            <p>{successStory.description}.</p>
+            <LinkFilled
+                id={`success-story-banner/${pageId}`}
+                href={`/success-stories/${successStory.slug}`}
+                target="_blank"
+            >
+                Read Success Story
+            </LinkFilled>
+        </div>
+    );
+};
+
+export default SuccessStoryBanner;

--- a/src/components/SuccessStoryBanner/index.tsx
+++ b/src/components/SuccessStoryBanner/index.tsx
@@ -26,11 +26,7 @@ const SuccessStoryBanner = ({
                 logo: Logo {
                     localFile {
                         childImageSharp {
-                            gatsbyImageData(
-                                layout: CONSTRAINED
-                                placeholder: BLURRED
-                                quality: 100
-                            )
+                            gatsbyImageData(placeholder: BLURRED, quality: 100)
                         }
                     }
                 }

--- a/src/components/SuccessStoryBanner/styles.module.less
+++ b/src/components/SuccessStoryBanner/styles.module.less
@@ -1,0 +1,59 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  background-color: #FFA80050;
+  border: 1px solid #FFA800CC;
+  border-radius: 12px;
+  padding: 24px;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+
+  p {
+    font-weight: 500;
+    margin: 0;
+    flex: 1;
+  }
+
+  @media (max-width: 1380px) {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    grid-template-rows: auto auto;
+    gap: 12px;
+    padding: 24px;
+
+    p {
+      grid-column: 1;
+      grid-row: 2;
+      grid-column: span 2;
+    }
+
+    a {
+      width: fit-content;
+      margin-left: auto;
+      white-space: nowrap;
+    }
+  }
+
+  @media (max-width: 600px) {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+
+    a {
+      width: 100%;
+      white-space: normal;
+    }
+  }
+}
+
+.darkBackgroundColor {
+  background-color: var(--dark-blue);
+}
+
+.imageWrapper {
+  max-width: 200px;
+}

--- a/src/components/SuccessStoryBanner/styles.module.less
+++ b/src/components/SuccessStoryBanner/styles.module.less
@@ -2,8 +2,8 @@
   display: flex;
   align-items: center;
   gap: 24px;
-  background-color: #FFA80050;
-  border: 1px solid #FFA800CC;
+  background-color: var(--banner-background-color);
+  border: 1px solid var(--banner-border-color);
   border-radius: 12px;
   padding: 24px;
 

--- a/src/style.less
+++ b/src/style.less
@@ -41,6 +41,9 @@
     --green: #00A99D;
     --light-green: #37C0C1;
     --red: #FF3A44;
+    --banner-background-color: #FFA80040;
+    --banner-hover-background-color: #FFA80050;
+    --banner-border-color: #FFA800CC;
 }
 
 /* HTML elements */


### PR DESCRIPTION
#749 

## Changes

-   Create component for the success story banner and use headset as default for now;
-   Add it to the comparison page;
-   For now we will use the banner only in the estuary vs airbyte comparison page;
-   Button is opening the headset success story page in a new tab.

## Tests / Screenshots

-   Desktop:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/d7895037-2b6f-46e5-b385-c24889b95c0c" />

-   Mobile:
<img width="318" alt="image" src="https://github.com/user-attachments/assets/e96b9863-37ea-4b3a-bc4f-e46bb2d1759d" />

