### PR TITLE
Blog post and schema date fixes

### DIFF
--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -121,14 +121,9 @@ const BlogPost = ({
                                     <span className={blogPostDate}>
                                         <span>
                                             {hasBeenUpdated
-                                                ? `Published ${post.publishedAt}`
+                                                ? `Last updated: ${post.updatedAt}`
                                                 : post.publishedAt}
                                         </span>
-                                        {hasBeenUpdated ? (
-                                            <span>
-                                                Updated {post.updatedAt}
-                                            </span>
-                                        ) : null}
                                     </span>
                                 </div>
                             </div>

--- a/src/components/CompanyUpdatesPage/ListOfUpdates/index.tsx
+++ b/src/components/CompanyUpdatesPage/ListOfUpdates/index.tsx
@@ -18,12 +18,6 @@ const ListOfUpdates = () => {
                     title
                     publishedAt(formatString: "MMMM D, YYYY")
                     postedDate: updatedAt(formatString: "MMMM D, YYYY")
-                    machineReadablePublishDate: publishedAt(
-                        formatString: "YYYY-MM-DD"
-                    )
-                    machineReadableUpdateDate: updatedAt(
-                        formatString: "YYYY-MM-DD"
-                    )
                     description
                     slug
                     picture: hero {

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -109,8 +109,12 @@ export const pageQuery = graphql`
             title: Title
             publishedAt(formatString: "MMMM D, YYYY")
             updatedAt(formatString: "MMMM D, YYYY")
-            machineReadablePublishDate: publishedAt(formatString: "YYYY-MM-DD")
-            machineReadableUpdateDate: updatedAt(formatString: "YYYY-MM-DD")
+            machineReadablePublishDate: publishedAt(
+                formatString: "YYYY-MM-DD[T]HH:mm:ssZ"
+            )
+            machineReadableUpdateDate: updatedAt(
+                formatString: "YYYY-MM-DD[T]HH:mm:ssZ"
+            )
             description: Description
             slug: Slug
             body: Body {

--- a/src/templates/company-update-post/index.tsx
+++ b/src/templates/company-update-post/index.tsx
@@ -98,8 +98,12 @@ export const pageQuery = graphql`
             title
             publishedAt(formatString: "MMMM D, YYYY")
             updatedAt(formatString: "MMMM D, YYYY")
-            machineReadablePublishDate: publishedAt(formatString: "YYYY-MM-DD")
-            machineReadableUpdateDate: updatedAt(formatString: "YYYY-MM-DD")
+            machineReadablePublishDate: publishedAt(
+                formatString: "YYYY-MM-DD[T]HH:mm:ssZ"
+            )
+            machineReadableUpdateDate: updatedAt(
+                formatString: "YYYY-MM-DD[T]HH:mm:ssZ"
+            )
             description
             slug
             body {

--- a/src/templates/success-story/index.tsx
+++ b/src/templates/success-story/index.tsx
@@ -37,7 +37,6 @@ export const pageQuery = graphql`
             }
         }
         successStory: strapiCaseStudy(id: { eq: $id }) {
-            machineReadablePublishDate: publishedAt(formatString: "YYYY-MM-DD")
             metaTitle
             metaDescription
             Slug


### PR DESCRIPTION
#777

## Changes

-   Show Only “Last Updated” when blog post was updated;
-   Remove some unused data from some queries;
-   Update schema dates to ISO8601 format with time and timezone for blog post template and company update post template pages

## Tests / Screenshots

Tested locally:

- When the blog post has only publish date:
<img width="897" alt="image" src="https://github.com/user-attachments/assets/9af8f26c-549d-4b05-beb5-6dec76ff895e" />

- When the blog post has update date:
<img width="895" alt="image" src="https://github.com/user-attachments/assets/4b89c8b3-1eff-44c8-a0cf-93655b3de6bc" />

- Schema updated with time and timezone - ISO8601 format:
<img width="933" alt="image" src="https://github.com/user-attachments/assets/72b5a117-9d99-4d3c-8f27-7d82fbb66296" />