### PR TITLE
Add expandable FAQ section with FAQ schema for blog posts

### DIFF
--- a/src/components/BlogPost/Faq/index.tsx
+++ b/src/components/BlogPost/Faq/index.tsx
@@ -1,0 +1,44 @@
+import { useState, SyntheticEvent } from 'react';
+import { defaultWrapperGrey } from '../../../globalStyles/wrappers.module.less';
+import Container from '../../Container';
+import Accordion from '../../Faq/Accordion';
+import Wrapper from '../../Faq/Wrapper';
+
+const Faq = ({ faqs }) => {
+    const [expanded, setExpanded] = useState<string | null>(null);
+
+    const handleChange =
+        (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
+            setExpanded(isExpanded ? panel : null);
+        };
+
+    return (
+        <section className={defaultWrapperGrey}>
+            <Container isVertical>
+                <h2>FAQ</h2>
+                <Wrapper>
+                    {faqs.map(({ question, content }, index) => {
+                        const questionNumber = index + 1;
+                        return (
+                            <Accordion
+                                key={questionNumber}
+                                questionNumber={questionNumber}
+                                question={question}
+                                expanded={
+                                    expanded === `question${questionNumber}`
+                                }
+                                onChange={handleChange(
+                                    `question${questionNumber}`
+                                )}
+                            >
+                                {content}
+                            </Accordion>
+                        );
+                    })}
+                </Wrapper>
+            </Container>
+        </section>
+    );
+};
+
+export default Faq;

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -2,7 +2,7 @@ import FaqAccordions from '../../Faq/FaqAccordions';
 import { container } from './styles.module.less';
 
 const Faqs = ({ faqs }) => (
-    <div id="faq" className={container}>
+    <div id="blog-post-hardcoded-faq" className={container}>
         <h2>FAQ</h2>
         <FaqAccordions faqs={faqs} />
     </div>

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -3,15 +3,13 @@ import Container from '../../Container';
 import FaqAccordions from '../../Faq/FaqAccordions';
 import { sectionTitle } from './styles.module.less';
 
-const Faqs = ({ faqs }) => {
-    return (
-        <section className={defaultWrapperDark}>
-            <Container isVertical>
-                <h2 className={sectionTitle}>FAQ</h2>
-                <FaqAccordions faqs={faqs} />
-            </Container>
-        </section>
-    );
-};
+const Faqs = ({ faqs }) => (
+    <section className={defaultWrapperDark}>
+        <Container isVertical>
+            <h2 className={sectionTitle}>FAQ</h2>
+            <FaqAccordions faqs={faqs} />
+        </Container>
+    </section>
+);
 
 export default Faqs;

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -2,7 +2,7 @@ import FaqAccordions from '../../Faq/FaqAccordions';
 import { container } from './styles.module.less';
 
 const Faqs = ({ faqs }) => (
-    <div className={container}>
+    <div id="faq" className={container}>
         <h2>FAQ</h2>
         <FaqAccordions faqs={faqs} />
     </div>

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -1,42 +1,14 @@
-import { useState, SyntheticEvent } from 'react';
 import { defaultWrapperDark } from '../../../globalStyles/wrappers.module.less';
 import Container from '../../Container';
-import Accordion from '../../Faq/Accordion';
-import Wrapper from '../../Faq/Wrapper';
+import FaqAccordions from '../../Faq/FaqAccordions';
 import { sectionTitle } from './styles.module.less';
 
 const Faqs = ({ faqs }) => {
-    const [expanded, setExpanded] = useState<string | null>(null);
-
-    const handleChange =
-        (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
-            setExpanded(isExpanded ? panel : null);
-        };
-
     return (
         <section className={defaultWrapperDark}>
             <Container isVertical>
                 <h2 className={sectionTitle}>FAQ</h2>
-                <Wrapper>
-                    {faqs.map(({ question, answer }, index) => {
-                        const questionNumber = index + 1;
-                        return (
-                            <Accordion
-                                key={questionNumber}
-                                questionNumber={questionNumber}
-                                question={question}
-                                expanded={
-                                    expanded === `question${questionNumber}`
-                                }
-                                onChange={handleChange(
-                                    `question${questionNumber}`
-                                )}
-                            >
-                                {answer}
-                            </Accordion>
-                        );
-                    })}
-                </Wrapper>
+                <FaqAccordions faqs={faqs} />
             </Container>
         </section>
     );

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -1,10 +1,11 @@
 import { useState, SyntheticEvent } from 'react';
-import { defaultWrapperGrey } from '../../../globalStyles/wrappers.module.less';
+import { defaultWrapperDark } from '../../../globalStyles/wrappers.module.less';
 import Container from '../../Container';
 import Accordion from '../../Faq/Accordion';
 import Wrapper from '../../Faq/Wrapper';
+import { sectionTitle } from './styles.module.less';
 
-const Faq = ({ faqs }) => {
+const Faqs = ({ faqs }) => {
     const [expanded, setExpanded] = useState<string | null>(null);
 
     const handleChange =
@@ -13,11 +14,11 @@ const Faq = ({ faqs }) => {
         };
 
     return (
-        <section className={defaultWrapperGrey}>
+        <section className={defaultWrapperDark}>
             <Container isVertical>
-                <h2>FAQ</h2>
+                <h2 className={sectionTitle}>FAQ</h2>
                 <Wrapper>
-                    {faqs.map(({ question, content }, index) => {
+                    {faqs.map(({ question, answer }, index) => {
                         const questionNumber = index + 1;
                         return (
                             <Accordion
@@ -31,7 +32,7 @@ const Faq = ({ faqs }) => {
                                     `question${questionNumber}`
                                 )}
                             >
-                                {content}
+                                {answer}
                             </Accordion>
                         );
                     })}
@@ -41,4 +42,4 @@ const Faq = ({ faqs }) => {
     );
 };
 
-export default Faq;
+export default Faqs;

--- a/src/components/BlogPost/Faqs/index.tsx
+++ b/src/components/BlogPost/Faqs/index.tsx
@@ -1,15 +1,11 @@
-import { defaultWrapperDark } from '../../../globalStyles/wrappers.module.less';
-import Container from '../../Container';
 import FaqAccordions from '../../Faq/FaqAccordions';
-import { sectionTitle } from './styles.module.less';
+import { container } from './styles.module.less';
 
 const Faqs = ({ faqs }) => (
-    <section className={defaultWrapperDark}>
-        <Container isVertical>
-            <h2 className={sectionTitle}>FAQ</h2>
-            <FaqAccordions faqs={faqs} />
-        </Container>
-    </section>
+    <div className={container}>
+        <h2>FAQ</h2>
+        <FaqAccordions faqs={faqs} />
+    </div>
 );
 
 export default Faqs;

--- a/src/components/BlogPost/Faqs/styles.module.less
+++ b/src/components/BlogPost/Faqs/styles.module.less
@@ -1,4 +1,8 @@
-.sectionTitle {
-  font-weight: 700;
-  font-size: 2.25rem;
+.container {
+  margin-bottom: 24px;
+
+  h2 {
+    font-weight: 600;
+    font-size: 2.25rem;
+  }
 }

--- a/src/components/BlogPost/Faqs/styles.module.less
+++ b/src/components/BlogPost/Faqs/styles.module.less
@@ -1,0 +1,4 @@
+.sectionTitle {
+  font-weight: 700;
+  font-size: 2.25rem;
+}

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -198,7 +198,10 @@ const BlogPost = ({
                                 post?.faq?.length > 0
                                     ? [
                                           ...bodyToc,
-                                          { id: 'faq', heading: 'FAQ' },
+                                          {
+                                              id: 'blog-post-hardcoded-faq',
+                                              heading: 'FAQ',
+                                          },
                                       ]
                                     : bodyToc
                             }

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -167,6 +167,9 @@ const BlogPost = ({
                             <ProcessedPost
                                 body={post.body.data.childHtmlRehype.html}
                             />
+                            {post?.faq?.length > 0 ? (
+                                <Faqs faqs={post.faq} />
+                            ) : null}
                             {hasBodyCtaBanner ? (
                                 <BlogBanner
                                     title={
@@ -316,7 +319,6 @@ const BlogPost = ({
                     <PopularArticles />
                 </section>
             ) : null}
-            {post?.faq?.length > 0 ? <Faqs faqs={post.faq} /> : null}
             <section className={bigBuildPipelineBannerSection}>
                 <div className={bigBuildPipelineBannerWrapper}>
                     <StraightLinesBackground

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -58,7 +58,7 @@ import {
     authorName,
     authorRole,
 } from './styles.module.less';
-import Faq from './Faq';
+import Faqs from './Faqs';
 
 interface BlogPostProps {
     post: any;
@@ -197,7 +197,6 @@ const BlogPost = ({
                     </div>
                 </section>
             ) : null}
-            <Faq faqs={post.faq} />
             {post?.authors?.length >= 1 ? (
                 <section className={nextStepsAndAboutAuthorSection}>
                     {/* <div className={nextSteps}>
@@ -317,6 +316,7 @@ const BlogPost = ({
                     <PopularArticles />
                 </section>
             ) : null}
+            {post?.faq?.length > 0 ? <Faqs faqs={post.faq} /> : null}
             <section className={bigBuildPipelineBannerSection}>
                 <div className={bigBuildPipelineBannerWrapper}>
                     <StraightLinesBackground

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -85,6 +85,8 @@ const BlogPost = ({
 
     const shareArticleSectionTitle = `Share this ${hasPopularArticlesSection ? 'article' : 'update'}`;
 
+    const bodyToc = post.body.data.childHtmlRehype.tableOfContents;
+
     return (
         <article
             className={article}
@@ -193,7 +195,12 @@ const BlogPost = ({
                                 slug: post.slug,
                             }}
                             tableOfContents={
-                                post.body.data.childHtmlRehype.tableOfContents
+                                post.faq
+                                    ? [
+                                          ...bodyToc,
+                                          { id: 'faq', heading: 'FAQ' },
+                                      ]
+                                    : bodyToc
                             }
                             shareArticleSectionTitle={shareArticleSectionTitle}
                         />

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -58,6 +58,7 @@ import {
     authorName,
     authorRole,
 } from './styles.module.less';
+import Faq from './Faq';
 
 interface BlogPostProps {
     post: any;
@@ -196,6 +197,7 @@ const BlogPost = ({
                     </div>
                 </section>
             ) : null}
+            <Faq faqs={post.faq} />
             {post?.authors?.length >= 1 ? (
                 <section className={nextStepsAndAboutAuthorSection}>
                     {/* <div className={nextSteps}>

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -195,7 +195,7 @@ const BlogPost = ({
                                 slug: post.slug,
                             }}
                             tableOfContents={
-                                post.faq
+                                post?.faq?.length > 0
                                     ? [
                                           ...bodyToc,
                                           { id: 'faq', heading: 'FAQ' },

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -188,6 +188,9 @@
 .mainContent {
   width: calc(100% - 256px - 48px);
   padding-left: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 
   @media (max-width: 1024px) {
     width: 100%;

--- a/src/components/Faq/FaqAccordions/index.tsx
+++ b/src/components/Faq/FaqAccordions/index.tsx
@@ -1,0 +1,47 @@
+import { useState, SyntheticEvent, ReactNode } from 'react';
+import Accordion from '../Accordion';
+import Wrapper from '../Wrapper';
+
+export interface FaqItem {
+    question: string;
+    answer: ReactNode;
+}
+
+interface FaqAccordionsProps {
+    faqs: FaqItem[];
+}
+
+const FaqAccordions = ({ faqs }: FaqAccordionsProps) => {
+    const [expanded, setExpanded] = useState<string | null>(null);
+
+    const handleChange =
+        (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
+            setExpanded(isExpanded ? panel : null);
+        };
+
+    return (
+        <Wrapper>
+            {faqs.map(({ question, answer }, index) => {
+                if (!answer) {
+                    return null;
+                }
+
+                const questionNumber = index + 1;
+
+                return (
+                    <Accordion
+                        key={`question-${questionNumber}-from-faq-section`}
+                        questionNumber={questionNumber}
+                        question={question}
+                        expanded={expanded === `question${questionNumber}`}
+                        onChange={handleChange(`question${questionNumber}`)}
+                    >
+                        {answer}
+                    </Accordion>
+                );
+            })}
+        </Wrapper>
+    );
+};
+
+export default FaqAccordions;

--- a/src/components/Integration/Faq/faqs.tsx
+++ b/src/components/Integration/Faq/faqs.tsx
@@ -1,11 +1,14 @@
 import OutboundLink from '../../LinksAndButtons/OutboundLink';
 import InternalLink from '../../InternalLink';
 import { Connector } from '../../../../shared';
+import { FaqItem } from '../../Faq/FaqAccordions';
 
-export const faqs = (sourceConnector: Partial<Connector>) => [
+export const faqs = (
+    sourceConnector: Partial<Connector>
+): (FaqItem | null)[] => [
     {
         question: 'What is the difference between ETL, ELT, and CDC?',
-        content: (
+        answer: (
             <>
                 <p>
                     <InternalLink
@@ -39,7 +42,7 @@ export const faqs = (sourceConnector: Partial<Connector>) => [
     null
         ? {
               question: `What is ${sourceConnector.title}?`,
-              content: (
+              answer: (
                   <div
                       dangerouslySetInnerHTML={{
                           __html:
@@ -53,7 +56,7 @@ export const faqs = (sourceConnector: Partial<Connector>) => [
         : null,
     {
         question: `How do I Transfer Data from ${sourceConnector.title}?`,
-        content: (
+        answer: (
             <ol>
                 <li>
                     <span>Set Up Capture</span>: In Estuary Flow, go to{' '}
@@ -74,7 +77,7 @@ export const faqs = (sourceConnector: Partial<Connector>) => [
     },
     {
         question: 'What are the pricing options for Estuary Flow?',
-        content: (
+        answer: (
             <p>
                 Estuary offers competitive and transparent pricing, with a free
                 tier that includes 2 connector instances and up to 10 GB of data

--- a/src/components/Integration/Faq/index.tsx
+++ b/src/components/Integration/Faq/index.tsx
@@ -1,9 +1,7 @@
-import { SyntheticEvent, useState } from 'react';
 import { defaultWrapperGrey } from '../../../globalStyles/wrappers.module.less';
 import Container from '../../Container';
-import Accordion from '../../Faq/Accordion';
-import Wrapper from '../../Faq/Wrapper';
 import { Connector } from '../../../../shared';
+import FaqAccordions from '../../Faq/FaqAccordions';
 import { container } from './styles.module.less';
 import { faqs } from './faqs';
 
@@ -12,42 +10,13 @@ interface FaqProps {
 }
 
 const Faq = ({ sourceConnector }: FaqProps) => {
-    const [expanded, setExpanded] = useState<string | null>(null);
-
-    const handleChange =
-        (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
-            setExpanded(isExpanded ? panel : null);
-        };
-
     return (
         <section className={defaultWrapperGrey}>
             <Container isVertical className={container}>
                 <h2>FAQ</h2>
-                <Wrapper>
-                    {faqs(sourceConnector).map((faq, index) => {
-                        if (!faq) {
-                            return null;
-                        }
-
-                        const questionNumber = index + 1;
-
-                        return (
-                            <Accordion
-                                key={`question-${questionNumber}-from-faq-section`}
-                                questionNumber={questionNumber}
-                                question={faq.question}
-                                expanded={
-                                    expanded === `question${questionNumber}`
-                                }
-                                onChange={handleChange(
-                                    `question${questionNumber}`
-                                )}
-                            >
-                                {faq.content}
-                            </Accordion>
-                        );
-                    })}
-                </Wrapper>
+                <FaqAccordions
+                    faqs={faqs(sourceConnector).filter((faq) => faq != null)}
+                />
             </Container>
         </section>
     );

--- a/src/components/PricingPage/Faq/faqs.tsx
+++ b/src/components/PricingPage/Faq/faqs.tsx
@@ -12,7 +12,7 @@ import {
 export const faqs = [
     {
         question: 'How is my bill calculated?',
-        content: (
+        answer: (
             <>
                 <h4>Your bill has two main components:</h4>
                 <p>
@@ -36,7 +36,7 @@ export const faqs = [
     },
     {
         question: 'Do you offer discounted rates?',
-        content: (
+        answer: (
             <p>
                 Yes, discounts are available based on volume commitments and
                 contract duration.
@@ -45,7 +45,7 @@ export const faqs = [
     },
     {
         question: 'How does Pay-as-you-Go pricing work?',
-        content: (
+        answer: (
             <p>
                 For new users or those not wanting to commit to specific data
                 volumes, pay monthly based on actual data usage and active
@@ -56,7 +56,7 @@ export const faqs = [
     },
     {
         question: 'How does pre-pay work?',
-        content: (
+        answer: (
             <p>
                 Pay upfront for a fixed data transfer amount, usable over up to
                 12 months. Higher upfront payments receive greater discounts.
@@ -65,7 +65,7 @@ export const faqs = [
     },
     {
         question: 'What are pricing examples?',
-        content: (
+        answer: (
             <div className={answerSections}>
                 <div
                     className={clsx(answerSection, flexDirectionColumnReverse)}
@@ -117,7 +117,7 @@ export const faqs = [
     },
     {
         question: 'How does the Free Trial work?',
-        content: (
+        answer: (
             <p>
                 The free trial provides new users with 30 days of access to all
                 the features of our Cloud Plan. At the end of the trial period,
@@ -130,7 +130,7 @@ export const faqs = [
     },
     {
         question: 'What are my billing options?',
-        content: (
+        answer: (
             <>
                 <p>
                     <span>Free:</span> No credit card or billing information
@@ -148,7 +148,7 @@ export const faqs = [
     },
     {
         question: 'Where is my data stored?',
-        content: (
+        answer: (
             <p>
                 In the Free Plan, your data is securely stored in Estuary&apos;s
                 cloud storage and retained for a limited period. With the Cloud

--- a/src/components/PricingPage/Faq/index.tsx
+++ b/src/components/PricingPage/Faq/index.tsx
@@ -1,43 +1,15 @@
-import { useState, SyntheticEvent } from 'react';
 import { defaultWrapperGrey } from '../../../globalStyles/wrappers.module.less';
 import Container from '../../Container';
-import Accordion from '../../Faq/Accordion';
-import Wrapper from '../../Faq/Wrapper';
+import FaqAccordions from '../../Faq/FaqAccordions';
 import { title } from './styles.module.less';
 import { faqs } from './faqs';
 
 const Faq = () => {
-    const [expanded, setExpanded] = useState<string | null>(null);
-
-    const handleChange =
-        (panel: string) => (_event: SyntheticEvent, isExpanded: boolean) => {
-            setExpanded(isExpanded ? panel : null);
-        };
-
     return (
         <section className={defaultWrapperGrey}>
             <Container isVertical>
                 <h2 className={title}>FAQ</h2>
-                <Wrapper>
-                    {faqs.map(({ question, content }, index) => {
-                        const questionNumber = index + 1;
-                        return (
-                            <Accordion
-                                key={questionNumber}
-                                questionNumber={questionNumber}
-                                question={question}
-                                expanded={
-                                    expanded === `question${questionNumber}`
-                                }
-                                onChange={handleChange(
-                                    `question${questionNumber}`
-                                )}
-                            >
-                                {content}
-                            </Accordion>
-                        );
-                    })}
-                </Wrapper>
+                <FaqAccordions faqs={faqs} />
             </Container>
         </section>
     );

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -133,6 +133,7 @@ export const pageQuery = graphql`
                     }
                 }
             }
+            faq
             authors {
                 id
                 name: Name

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -133,7 +133,10 @@ export const pageQuery = graphql`
                     }
                 }
             }
-            faq
+            faq {
+                question
+                answer
+            }
             authors {
                 id
                 name: Name

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -92,6 +92,20 @@ export const Head = ({
                     'dateModified': post.machineReadableUpdateDate,
                 })}
             </script>
+            <script type="application/ld+json">
+                {JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'FAQPage',
+                    'mainEntity': post.faq.map(({ question, answer }) => ({
+                        '@type': 'Question',
+                        'name': question,
+                        'acceptedAnswer': {
+                            '@type': 'Answer',
+                            'text': answer,
+                        },
+                    })),
+                })}
+            </script>
         </>
     );
 };

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -92,20 +92,22 @@ export const Head = ({
                     'dateModified': post.machineReadableUpdateDate,
                 })}
             </script>
-            <script type="application/ld+json">
-                {JSON.stringify({
-                    '@context': 'https://schema.org',
-                    '@type': 'FAQPage',
-                    'mainEntity': post.faq.map(({ question, answer }) => ({
-                        '@type': 'Question',
-                        'name': question,
-                        'acceptedAnswer': {
-                            '@type': 'Answer',
-                            'text': answer,
-                        },
-                    })),
-                })}
-            </script>
+            {post?.faq ? (
+                <script type="application/ld+json">
+                    {JSON.stringify({
+                        '@context': 'https://schema.org',
+                        '@type': 'FAQPage',
+                        'mainEntity': post.faq.map(({ question, answer }) => ({
+                            '@type': 'Question',
+                            'name': question,
+                            'acceptedAnswer': {
+                                '@type': 'Answer',
+                                'text': answer,
+                            },
+                        })),
+                    })}
+                </script>
+            ) : null}
         </>
     );
 };


### PR DESCRIPTION
#554

## Changes

-   Add faq to blog post query;
-   Create a component FaqAccordions to reuse the FAQ sections code;
-   Add FAQ section to the blog post right above the last CTA banner;
-   Add FAQ schema to the Head of the blog post page.

## Tests / Screenshots

-   Blog post FAQs:
<img width="465" alt="image" src="https://github.com/user-attachments/assets/bf41e549-b6c6-40b6-8476-85101be94c0d" />

-    Blog post FAQ schema:
<img width="572" alt="image" src="https://github.com/user-attachments/assets/0a0a4c73-1634-4e22-a729-91297da0bec1" />