### PR TITLE
Update homepage release banner texts

### DIFF
--- a/src/components/Layout/ReleaseBanner/index.tsx
+++ b/src/components/Layout/ReleaseBanner/index.tsx
@@ -24,10 +24,10 @@ const ReleaseBanner = ({ theme = 'dark' }) => {
                     href="/deployment-options/"
                     rel="noreferrer"
                 >
-                    <span>A Step Ahead</span>
+                    <span>RSVP Now</span>
                     <p>
-                        Private deployments are now live! Explore how Estuary
-                        Flow can fit into your environment.
+                        Meet data pros in NYC! Join the Real-time Data Meetup
+                        for networking & streaming pipeline insights.
                     </p>
                     <ArrowRight color="var(--white)" />
                 </a>


### PR DESCRIPTION
#793

## Changes

-   Update release banner texts on the homepage.

## Tests / Screenshots

<img width="676" alt="image" src="https://github.com/user-attachments/assets/2aa7e80d-4e16-4920-a44f-07c37d28c37b" />

<img width="576" alt="image" src="https://github.com/user-attachments/assets/5f319ad8-b61b-444a-a88f-c40d677c63e8" />