### PR TITLE
Remove the unnecessary right padding of the marquee

### DIFF
--- a/src/components/VanityLogosMarquee/styles.less
+++ b/src/components/VanityLogosMarquee/styles.less
@@ -63,10 +63,6 @@
   .rfm-marquee:first-child {
     margin-right: 100px;
   }
-
-  .rfm-initial-child-container {
-    padding-right: 60px;
-  }
 }
 
 .vanity-logo {


### PR DESCRIPTION
#803

## Changes

-   Remove the unnecessary right padding of the marquee.

## Tests / Screenshots

<img width="842" alt="image" src="https://github.com/user-attachments/assets/fdaf7ce7-fabb-4061-b258-63517df878db" />