### PR TITLE
Fit text and button in video

### DIFF
--- a/src/components/FlowDemoVideo/styles.module.less
+++ b/src/components/FlowDemoVideo/styles.module.less
@@ -5,7 +5,6 @@
     padding: 18px;
     position: relative;
     width: 816px;
-    height: 540px;
 
     @media (max-width: 1280px) {
         width: fit-content;
@@ -25,36 +24,42 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 32px;
+    gap: 88px;
     color: var(--white);
     padding: 0 60px;
     text-align: center;
 
-    @media (max-width: 768px) {
-        font-size: 1.25rem;
-        line-height: normal;
+    @media (max-width: 1280px) {
+        gap: 100px;
+        margin-bottom: 16px;
     }
 
-    @media (max-width: 425px) {
-        font-size: 3.5vw;
-        gap: 4vw;
+    @media (max-width: 768px) {
+        font-size: 3vw;
+        line-height: normal;
+        gap: 12vw;
+        margin-bottom: 5vw;
     }
 
     button {
-        margin: 65px;
         padding: 16px 24px;
         gap: 16px;
+        margin-bottom: 54px;
 
-        @media (max-width: 425px) {
-            font-size: 2.5vw;
+        @media (max-width: 768px) {
             padding: 1vw 2vw;
-            gap: 4vw;
-            white-space: nowrap;
-            max-height: 8vw;
+            font-size: 2.5vw;
+            margin-bottom: 3.5vw;
 
             svg {
                 width: 3vw;
             }
+        }
+
+        @media (max-width: 425px) {
+            gap: 4vw;
+            white-space: nowrap;
+            max-height: 8vw;
         }
     }
 }


### PR DESCRIPTION
#808 

## Changes

-   Fit text and button in video making it responsive for all device screen widths.

## Tests / Screenshots

-   Desktop:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/6163c51e-c8c3-425c-87cf-12497959e955" />

-   Mobile:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/f4cc2e23-de45-4c25-9986-9c0a19c0d067" />