### PR TITLE
Centralize Qlik logo in the comparison page and selects

### DIFF
--- a/src/components/EtlToolsXvsYPage/Hero/styles.module.less
+++ b/src/components/EtlToolsXvsYPage/Hero/styles.module.less
@@ -7,6 +7,24 @@
   position: absolute;
   max-width: 9%;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 55px;
+
+  @media (max-width: 1700px) {
+    height: 3.5vw;
+  }
+
+  @media (max-width: 1024px) {
+    width: 5rem;
+    height: 5rem;
+  }
+
+  @media (max-width: 995px) {
+    width: 16%;
+    height: 16%;
+  }
 }
 
 .leftVendorLogo {
@@ -17,4 +35,26 @@
 .rightVendorLogo {
   top: 64.5%;
   left: 78.5%;
+}
+
+@media (max-width: 1024px) {
+  .rightVendorLogo {
+    left: 39.5rem;
+  }
+}
+
+@media (max-width: 995px) {
+  .leftVendorLogo {
+    right: 63vw;
+  }
+
+  .rightVendorLogo {
+    left: 78%;
+  }
+}
+
+@media (max-width: 425px) {
+  .leftVendorLogo {
+    right: 78.5%;
+  }
 }

--- a/src/components/XvsYFilter/index.tsx
+++ b/src/components/XvsYFilter/index.tsx
@@ -124,7 +124,7 @@ const XvsYFilter = ({
                                     className={itemImage}
                                 />
                             )}
-                            {item.title}
+                            <span>{item.title}</span>
                         </MenuItem>
                     ))}
                 </Select>
@@ -172,7 +172,7 @@ const XvsYFilter = ({
                                     className={itemImage}
                                 />
                             )}
-                            {item.title}
+                            <span>{item.title}</span>
                         </MenuItem>
                     ))}
                 </Select>

--- a/src/components/XvsYFilter/styles.module.less
+++ b/src/components/XvsYFilter/styles.module.less
@@ -23,13 +23,36 @@
 }
 
 .selectItem {
-    align-items: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 15px;
 }
 
 .itemImage {
     width: 20px;
-    margin-right: 15px;
-    vertical-align: middle;
+}
+
+.connectorSelect {
+    :global(.MuiSelect-select) {
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        margin-right: auto;
+
+        @media (min-width: 961px), (max-width: 320px) {
+            span {
+                display: inline-block;
+                width: 100px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+
+                @media (max-width: 1485px) {
+                    max-width: 100%;
+                }
+            }
+        }
+    }
 }
 
 .darkTheme {


### PR DESCRIPTION
#813

## Changes

-   Centralize the Qlik vendor icon in the comparison page and selects.

## Tests / Screenshots

-   Desktop:
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/d3a98d5f-c5aa-463e-84d7-a1428073194d" />

-   Mobile:
<img width="510" alt="image" src="https://github.com/user-attachments/assets/ceec6902-9bd4-46ec-a6c6-0c35489ce332" />