### PR TITLE
Remove `dayjs` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/lunr": "^2.3.4",
     "@types/react-dom": "^18.0.11",
     "clsx": "^1.2.1",
-    "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",
     "embla-carousel": "^8.2.0",
     "embla-carousel-react": "^8.2.0",

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -1,6 +1,4 @@
 import { graphql } from 'gatsby';
-import dayjs from 'dayjs';
-import reltime from 'dayjs/plugin/relativeTime';
 import BlogPostPopupModal from '../../components/BlogPostPopupModal';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Layout from '../../components/Layout';
@@ -8,9 +6,6 @@ import Seo from '../../components/seo';
 import logoUrl from '../../images/estuary.png';
 import { getAuthorSeoJson } from '../../../shared';
 import BlogPost from '../../components/BlogPost';
-
-// TODO: Change this to the one Travis suggested.
-dayjs.extend(reltime);
 
 const BlogPostTemplate = ({ data: { post } }) => {
     return (

--- a/src/templates/company-update-post/index.tsx
+++ b/src/templates/company-update-post/index.tsx
@@ -1,13 +1,9 @@
 import { graphql } from 'gatsby';
-import dayjs from 'dayjs';
-import reltime from 'dayjs/plugin/relativeTime';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Layout from '../../components/Layout';
 import Seo from '../../components/seo';
 import logoUrl from '../../images/estuary.png';
 import BlogPost from '../../components/BlogPost';
-
-dayjs.extend(reltime);
 
 const CompanyUpdatePostTemplate = ({ data: { post } }) => {
     const postWithPrefixedSlug = {

--- a/src/templates/success-story/index.tsx
+++ b/src/templates/success-story/index.tsx
@@ -1,13 +1,9 @@
 import { graphql } from 'gatsby';
-import dayjs from 'dayjs';
-import reltime from 'dayjs/plugin/relativeTime';
 import Wrapper from './Wrapper';
 import SectionBody from './Sections/Body';
 import Hero from './Sections/Hero';
 import Content from './Sections/Content';
 import SuccessStoryHead from './Head';
-
-dayjs.extend(reltime);
 
 const SuccessStoryTemplate = ({ data: { successStory } }) => {
     const { Title, Description, Logo, SideContent, About, Body } = successStory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5788,11 +5788,6 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-dayjs@^1.11.7:
-  version "1.11.7"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
-  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
-
 debug@2, debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
#760

## Changes

-   Remove dayjs dependency because it's not being used anywhere in fact. We already are formatting dates directly in the GraphQL queries.
-   So no need for replacing `dayjs` with `luxon`.

## Tests / Screenshots

-   Tested the blog posts, company update posts and success stories cards and the dates still look good as before:

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/5ce02453-1e8f-40b5-8c1b-f162e4f5b4ae" />
<img width="861" alt="image" src="https://github.com/user-attachments/assets/9002ddac-9511-454e-8443-7ddf855ae704" />
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/57931c3b-927d-458e-9205-8b07fb87db6f" />