### PR TITLE
Fix some sections on startup page on mobile

### DIFF
--- a/src/components/ConnectorsMasonrySection/styles.module.less
+++ b/src/components/ConnectorsMasonrySection/styles.module.less
@@ -33,6 +33,10 @@
         @media (max-width: 1024px) {
             max-width: 100%;
         }
+
+        @media (max-width: 768px) {
+            text-align: center;
+        }
     }
 
     p {

--- a/src/components/StartupPage/HaveQuestions/styles.module.less
+++ b/src/components/StartupPage/HaveQuestions/styles.module.less
@@ -29,6 +29,7 @@
   @media (max-width: 768px) {
     h2 {
       text-align: center;
+      font-size: 2.25rem;
     }
 
     a:first-of-type, a:last-of-type {

--- a/src/components/StartupPage/HaveQuestions/styles.module.less
+++ b/src/components/StartupPage/HaveQuestions/styles.module.less
@@ -20,9 +20,20 @@
     color: var(--dark-blue);
   }
 
-  a:hover, svg:hover {
+  a:hover,
+  svg:hover {
     color: var(--white);
     stroke: var(--white);
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      text-align: center;
+    }
+
+    a:first-of-type, a:last-of-type {
+      max-width: 100%;
+    }
   }
 
   @media (max-width: 425px) {

--- a/src/components/StartupPage/Hero/styles.module.less
+++ b/src/components/StartupPage/Hero/styles.module.less
@@ -5,15 +5,21 @@
   display: flex;
   flex-direction: column;
   gap: 100px;
+
+  .container:first-child {
+    img {
+      margin-left: auto;
+    }
+  }
+
+  .container:last-child {
+    img {
+      margin-right: auto;
+    }
+  }
 }
 
 .container {
-
-  > :nth-child(1),
-  :nth-child(2) {
-    max-width: fit-content;
-  }
-
   img {
     max-width: 536px;
     max-height: 536px;

--- a/src/components/StartupPage/Hero/styles.module.less
+++ b/src/components/StartupPage/Hero/styles.module.less
@@ -20,9 +20,16 @@
 }
 
 .container {
+
+  > :nth-child(1),
+  :nth-child(2) {
+    max-width: fit-content;
+  }
+
   img {
     max-width: 536px;
-    max-height: 536px;
+    width: 100%;
+    height: auto;
 
     @media (max-width: 1024px) {
       max-width: 100%;
@@ -83,10 +90,10 @@
   span {
     position: absolute;
     color: var(--white);
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 700;
 
-    @media (max-width: 1420px) {
+    @media (max-width: 1600px) {
       font-size: 1vw;
     }
 
@@ -100,12 +107,12 @@
   }
 
   span:first-of-type {
-    top: 179px;
-    right: 45px;
+    top: 204px;
+    right: 52px;
   }
 
   span:last-of-type {
-    top: 398px;
+    top: 454px;
     right: 34px;
     font-weight: 500;
 
@@ -115,7 +122,7 @@
     }
   }
 
-  @media (max-width: 1420px) {
+  @media (max-width: 1600px) {
     span:first-of-type {
       top: 33.5%;
       right: 8.4%;
@@ -134,10 +141,10 @@
   span {
     position: absolute;
     color: #4EFFF273;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     font-weight: 500;
 
-    @media (max-width: 1420px) {
+    @media (max-width: 1600px) {
       font-size: 0.875vw;
     }
 
@@ -151,18 +158,18 @@
   }
 
   span:first-of-type {
-    top: 42px;
-    left: 62px;
+    top: 47px;
+    left: 72px;
   }
 
   span:nth-of-type(2) {
-    top: 42px;
-    left: 374px;
+    top: 47px;
+    left: 426px;
   }
 
   span:last-of-type {
-    top: 300px;
-    left: 76px;
+    top: 342px;
+    left: 84px;
   }
 
   @media (max-width: 1600px) {
@@ -172,7 +179,7 @@
     }
   }
 
-  @media (max-width: 1420px) {
+  @media (max-width: 1600px) {
     span:first-of-type {
       top: 7.6%;
       left: 11%;

--- a/src/components/StartupPage/ReadyToGo/Card/styles.module.less
+++ b/src/components/StartupPage/ReadyToGo/Card/styles.module.less
@@ -20,14 +20,16 @@
     justify-content: space-between;
   }
 
-  img {
-    max-width: 238px;
-    max-height: 200px;
-  }
-
   &:hover {
     border-color: var(--violet300);
     cursor: pointer;
+  }
+
+  @media (min-width: 981px) {
+    img {
+      max-width: 238px;
+      max-height: 200px;
+    }
   }
 
   @media (max-width: 1580px) {

--- a/src/components/StartupPage/ReadyToGo/styles.module.less
+++ b/src/components/StartupPage/ReadyToGo/styles.module.less
@@ -4,6 +4,12 @@
     font-size: 2.5rem;
     font-weight: 600;
   }
+
+  @media (max-width: 768px) {
+    h2 {
+      text-align: center;
+    }
+  }
 }
 
 .cardsWrapper {
@@ -73,15 +79,15 @@
 
   @media (max-width: 980px) {
     span {
-      font-size: 0.6875rem;
+      font-size: 0.9rem;
     }
 
     span:nth-of-type(2) {
-      font-size: 0.75rem;
+      font-size: 0.95rem;
     }
   }
 
-  @media (max-width: 680px) {
+  @media (max-width: 850px) {
     span {
       font-size: 1.6vw;
     }
@@ -93,31 +99,11 @@
 
   @media (max-width: 500px) {
     span {
-      font-size: 2.25vw;
+      font-size: 3vw;
     }
 
     span:nth-of-type(2) {
-      font-size: 2.5vw;
-    }
-  }
-
-  @media (max-width: 425px) {
-    span {
-      font-size: 0.6875rem;
-    }
-
-    span:nth-of-type(2) {
-      font-size: 0.75rem;
-    }
-  }
-
-  @media (max-width: 310px) {
-    span {
-      font-size: 3.6vw;
-    }
-
-    span:nth-of-type(2) {
-      font-size: 3.85vw;
+      font-size: 3.25vw;
     }
   }
 }

--- a/src/components/StartupPage/WhatFoundersAreSaying/styles.module.less
+++ b/src/components/StartupPage/WhatFoundersAreSaying/styles.module.less
@@ -11,12 +11,18 @@
     max-width: 311px;
     width: 100%;
 
-    @media (max-width: 768px) {
-      margin: auto;
-    }
-
     @media (max-width: 425px) {
       max-width: 100%;
+    }
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      text-align: center;
+    }
+
+    a {
+      margin: auto;
     }
   }
 }

--- a/src/components/StartupPage/WhatsIncluded/styles.module.less
+++ b/src/components/StartupPage/WhatsIncluded/styles.module.less
@@ -21,12 +21,19 @@
     max-width: 311px;
     width: 100%;
 
-    @media (max-width: 768px) {
-      margin: auto;
-    }
-
     @media (max-width: 425px) {
       max-width: 100%;
+    }
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      margin-right: 0;
+      text-align: center;
+    }
+
+    a {
+      margin: auto;
     }
   }
 }


### PR DESCRIPTION
#823 

## Changes

-   Fix hero images on Safari desktop version;
-   Fix images from "Ready to go" section mobile version;
-   Centralize section titles on tablet+mobile

## Tests / Screenshots

-   Tested locally on Chrome and Safari and looks good.

- Hero images:
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/f5accc6d-9f69-4a0b-91b3-ad62735eaa3d" />
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/ae9e256e-25cd-4b2e-9af8-3db8eb7cf492" />

- Login image:
<img width="739" alt="image" src="https://github.com/user-attachments/assets/f17d0549-cd34-4836-a7b6-76063fb23820" />

- Buttons aligned:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/77ea2ff5-7c08-4a08-818a-18e5ade6b0c2" />