### PR TITLE
Add some fixes to the Estuary Flow video

### DIFF
--- a/src/components/FlowDemoVideo/index.tsx
+++ b/src/components/FlowDemoVideo/index.tsx
@@ -1,6 +1,6 @@
 import { StaticImage } from 'gatsby-plugin-image';
 import ReactPlayer from 'react-player';
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { estuaryProductFlowVideoUrl } from '../../../shared';
 import useWindowExistence from '../../hooks/useWindowExistence';
 import PlayIcon from '../../svgs/play.svg';

--- a/src/components/FlowDemoVideo/index.tsx
+++ b/src/components/FlowDemoVideo/index.tsx
@@ -1,6 +1,6 @@
 import { StaticImage } from 'gatsby-plugin-image';
 import ReactPlayer from 'react-player';
-import { useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { estuaryProductFlowVideoUrl } from '../../../shared';
 import useWindowExistence from '../../hooks/useWindowExistence';
 import PlayIcon from '../../svgs/play.svg';
@@ -9,6 +9,7 @@ import { container, videoTextAndButtonsWrapper } from './styles.module.less';
 
 const FlowDemoVideo = () => {
     const hasWindow = useWindowExistence();
+    const [isPlaying, setIsPlaying] = useState(false);
 
     const thumbnailComponent = useMemo(
         () => (
@@ -22,13 +23,20 @@ const FlowDemoVideo = () => {
         []
     );
 
-    return hasWindow ? (
+    const handlePreviewClick = () => setIsPlaying(true);
+
+    if (!hasWindow) return null;
+
+    return (
         <div className={container}>
             <ReactPlayer
                 light={thumbnailComponent}
                 url={estuaryProductFlowVideoUrl}
                 width="100%"
                 height="100%"
+                playing={isPlaying}
+                onClickPreview={handlePreviewClick}
+                controls
                 playIcon={
                     <div className={videoTextAndButtonsWrapper}>
                         <span>
@@ -42,7 +50,7 @@ const FlowDemoVideo = () => {
                 }
             />
         </div>
-    ) : null;
+    );
 };
 
 export default FlowDemoVideo;

--- a/src/components/FlowDemoVideo/styles.module.less
+++ b/src/components/FlowDemoVideo/styles.module.less
@@ -5,6 +5,7 @@
     padding: 18px;
     position: relative;
     width: 816px;
+    height: 475px;
 
     @media (max-width: 1280px) {
         width: fit-content;


### PR DESCRIPTION
#827

## Changes

-   Fix video Height;
-   Start playing video right after clicking play video button;
-   Add controls to the player.

## Tests / Screenshots

-   Tested locally all pages with video like homepage, integration and product pages.

-   Before clicking the Play Video button:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/f7e59e10-7492-4787-94eb-f84f2af672bc" />
-   After clicking the Play Video button
<img width="510" alt="image" src="https://github.com/user-attachments/assets/52d1a8ec-4ad0-4013-bec1-9a74161517d7" />
-   Mobile version working well:
<img width="164" alt="image" src="https://github.com/user-attachments/assets/a9cd7069-f398-479b-8176-cccde675a999" />