### PR TITLE
Add border left to the blockquotes

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -217,14 +217,14 @@ label {
 }
 
 blockquote {
+    color: var(--color-text-light);
+    margin-left: 2px;
+    margin-right: var(--spacing-8);
+    padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-6);
+    border-left: var(--spacing-1) solid var(--border-color);
     font-size: var(--fontSize-2);
-    margin: 0;
-    padding: 0;
-
-    cite {
-        font-size: 1rem;
-        font-style: normal;
-    }
+    font-style: italic;
+    margin-bottom: var(--spacing-8);
 }
 
 blockquote> :last-child {
@@ -370,6 +370,11 @@ table th {
 }
 
 @media (max-width: 42rem) {
+    blockquote {
+        padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-4);
+        margin-left: var(--spacing-0);
+    }
+
     ul,
     ol {
         list-style-position: inside;


### PR DESCRIPTION
#832 

## Changes

-   Add border left to the blockquotes globally.

## Tests / Screenshots

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/96c908f0-d817-444c-a94a-5a863b9cb5d9" />

