### PR TITLE
Add contact us form when connectors list is empty

### DIFF
--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -32,8 +32,6 @@ import {
     connectorCard,
     connectorBottomButton,
     contactUsForm,
-    contactUsFormWrapper,
-    hideContactUsForm,
 } from './styles.module.less';
 
 export interface ConnectorsProps {
@@ -293,17 +291,9 @@ export const Connectors = ({
                         <p>
                             Fill out the form and we will get back to you today.
                         </p>
+                        <ContactUsForm />
                     </div>
                 ) : null}
-                <div
-                    className={
-                        query !== '' && results.length === 0
-                            ? contactUsFormWrapper
-                            : hideContactUsForm
-                    }
-                >
-                    <ContactUsForm />
-                </div>
             </div>
             <>
                 <div className={connectorOnlycardsBackgroundImage}>

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -32,6 +32,7 @@ import {
     connectorCard,
     connectorBottomButton,
     contactUsForm,
+    additionalMarginTop,
 } from './styles.module.less';
 
 export interface ConnectorsProps {
@@ -285,15 +286,18 @@ export const Connectors = ({
                         }
                     )}
                 </div>
-                {query !== '' && results.length === 0 ? (
-                    <div className={contactUsForm}>
-                        <h2>Can&apos;t find your connector?</h2>
-                        <p>
-                            Fill out the form and we will get back to you today.
-                        </p>
-                        <ContactUsForm />
-                    </div>
-                ) : null}
+                <div
+                    className={clsx(
+                        contactUsForm,
+                        query !== '' && results.length === 0
+                            ? null
+                            : additionalMarginTop
+                    )}
+                >
+                    <h2>Can&apos;t find your connector?</h2>
+                    <p>Fill out the form and we will get back to you today.</p>
+                    <ContactUsForm />
+                </div>
             </div>
             <>
                 <div className={connectorOnlycardsBackgroundImage}>

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -13,6 +13,7 @@ import ConnectorsLink from '../ConnectorsLink';
 import SearchInput from '../SearchInput';
 import FlowLogoVector from '../FlowLogoVector';
 import ConnectorLogoPlaceholder from '../ConnectorLogoPlaceholder';
+import ContactUsForm from '../ContactUsForm/Form';
 import {
     container,
     connectorIndexHeader,
@@ -30,6 +31,7 @@ import {
     connectorCardReadMore,
     connectorCard,
     connectorBottomButton,
+    contactUsForm,
 } from './styles.module.less';
 
 export interface ConnectorsProps {
@@ -283,6 +285,16 @@ export const Connectors = ({
                         }
                     )}
                 </div>
+                {query !== '' && results.length === 0 ? (
+                    <div className={contactUsForm}>
+                        <h2>No results found</h2>
+                        <p>
+                            Would you like to request a connector? Fill out the
+                            form and we will get back to you.
+                        </p>
+                        <ContactUsForm />
+                    </div>
+                ) : null}
             </div>
             <>
                 <div className={connectorOnlycardsBackgroundImage}>

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -32,6 +32,8 @@ import {
     connectorCard,
     connectorBottomButton,
     contactUsForm,
+    contactUsFormWrapper,
+    hideContactUsForm,
 } from './styles.module.less';
 
 export interface ConnectorsProps {
@@ -291,9 +293,17 @@ export const Connectors = ({
                         <p>
                             Fill out the form and we will get back to you today.
                         </p>
-                        <ContactUsForm />
                     </div>
                 ) : null}
+                <div
+                    className={
+                        query !== '' && results.length === 0
+                            ? contactUsFormWrapper
+                            : hideContactUsForm
+                    }
+                >
+                    <ContactUsForm />
+                </div>
             </div>
             <>
                 <div className={connectorOnlycardsBackgroundImage}>

--- a/src/components/Connectors/index.tsx
+++ b/src/components/Connectors/index.tsx
@@ -287,10 +287,9 @@ export const Connectors = ({
                 </div>
                 {query !== '' && results.length === 0 ? (
                     <div className={contactUsForm}>
-                        <h2>No results found</h2>
+                        <h2>Can&apos;t find your connector?</h2>
                         <p>
-                            Would you like to request a connector? Fill out the
-                            form and we will get back to you.
+                            Fill out the form and we will get back to you today.
                         </p>
                         <ContactUsForm />
                     </div>

--- a/src/components/Connectors/styles.module.less
+++ b/src/components/Connectors/styles.module.less
@@ -249,3 +249,7 @@
     margin: 24px 0 48px 0;
   }
 }
+
+.additionalMarginTop {
+  margin-top: 120px;
+}

--- a/src/components/Connectors/styles.module.less
+++ b/src/components/Connectors/styles.module.less
@@ -249,12 +249,3 @@
     margin: 24px 0 48px 0;
   }
 }
-
-.contactUsFormWrapper {
-  margin: 60px auto 0 auto;
-  max-width: 792px;
-}
-
-.hideContactUsForm {
-  display: none;
-}

--- a/src/components/Connectors/styles.module.less
+++ b/src/components/Connectors/styles.module.less
@@ -230,3 +230,22 @@
     font-size: var(--fontSize-0);
   }
 }
+
+.contactUsForm {
+  text-align: center;
+  margin: 60px auto 0 auto;
+  max-width: 792px;
+
+  h2 {
+    font-size: 2.5rem;
+
+    @media (max-width: 768px) {
+      font-size: 1.5rem;
+    }
+  }
+
+  p {
+    font-size: 1rem;
+    margin: 24px 0 48px 0;
+  }
+}

--- a/src/components/Connectors/styles.module.less
+++ b/src/components/Connectors/styles.module.less
@@ -249,3 +249,12 @@
     margin: 24px 0 48px 0;
   }
 }
+
+.contactUsFormWrapper {
+  margin: 60px auto 0 auto;
+  max-width: 792px;
+}
+
+.hideContactUsForm {
+  display: none;
+}

--- a/src/components/ContactUsForm/Form.tsx
+++ b/src/components/ContactUsForm/Form.tsx
@@ -1,0 +1,24 @@
+import HubSpotFormWrapper from '../HubSpot/FormWrapper';
+import OutboundLink from '../LinksAndButtons/OutboundLink';
+import { contactUsFormHelpText, redirectLink } from './styles.module.less';
+
+const Form = () => {
+    return (
+        <>
+            <HubSpotFormWrapper formId="698e6716-f38b-4bd5-9105-df9ba220e29b" />
+            <p className={contactUsFormHelpText}>
+                If you don&apos;t see the form, please{' '}
+                <OutboundLink
+                    href="https://share.hsforms.com/1aY5nFvOLS9WRBd-boiDimw553hf"
+                    target="__blank"
+                    className={redirectLink}
+                >
+                    click here
+                </OutboundLink>{' '}
+                to open it in a new tab.
+            </p>
+        </>
+    );
+};
+
+export default Form;

--- a/src/components/ContactUsForm/index.tsx
+++ b/src/components/ContactUsForm/index.tsx
@@ -1,12 +1,5 @@
-import HubSpotFormWrapper from '../HubSpot/FormWrapper';
-import OutboundLink from '../LinksAndButtons/OutboundLink';
-import {
-    container,
-    title,
-    description,
-    contactUsFormHelpText,
-    redirectLink,
-} from './styles.module.less';
+import Form from './Form';
+import { container, title, description } from './styles.module.less';
 
 interface ContactUsFormProps {
     titleHeadingLevel?: 'h1' | 'h2' | 'h3';
@@ -24,18 +17,7 @@ const ContactUsForm = ({ titleHeadingLevel = 'h2' }: ContactUsFormProps) => {
                 Have a specific question or comment? Send us a note and a team
                 member will reach out to you shortly.
             </p>
-            <HubSpotFormWrapper formId="698e6716-f38b-4bd5-9105-df9ba220e29b" />
-            <p className={contactUsFormHelpText}>
-                If you don&apos;t see the form, please{' '}
-                <OutboundLink
-                    href="https://share.hsforms.com/1aY5nFvOLS9WRBd-boiDimw553hf"
-                    target="__blank"
-                    className={redirectLink}
-                >
-                    click here
-                </OutboundLink>{' '}
-                to open it in a new tab.
-            </p>
+            <Form />
         </div>
     );
 };


### PR DESCRIPTION
#840 

## Changes

-   Add contact us form when there is no connectors found.

## Tests / Screenshots

- Desktop
<img width="493" alt="image" src="https://github.com/user-attachments/assets/7541cdae-6855-4aae-8829-f9216a086ec2" />

- Mobile
<img width="496" alt="image" src="https://github.com/user-attachments/assets/59dfeb91-6f49-42de-93db-65eb3940f9ce" />