### PR TITLE
Add search for success stories

### DIFF
--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -1,4 +1,5 @@
 import SearchIcon from '@mui/icons-material/Search';
+import clsx from 'clsx';
 import {
     blogsIndexSearch,
     blogsIndexInputAdornment,
@@ -7,11 +8,16 @@ import {
 interface SearchInputProps {
     handleQueryChange: (evt: any) => void;
     placeholder?: string;
+    className?: string;
 }
 
-const SearchInput = ({ handleQueryChange, placeholder }: SearchInputProps) => {
+const SearchInput = ({
+    handleQueryChange,
+    placeholder,
+    className,
+}: SearchInputProps) => {
     return (
-        <div className={blogsIndexSearch}>
+        <div className={clsx(blogsIndexSearch, className)}>
             <SearchIcon className={blogsIndexInputAdornment} />
             <input
                 placeholder={placeholder}

--- a/src/components/SuccessStoriesPage/Hero/index.tsx
+++ b/src/components/SuccessStoriesPage/Hero/index.tsx
@@ -1,14 +1,8 @@
 import { StaticImage } from 'gatsby-plugin-image';
-import { IStaticImageProps } from 'gatsby-plugin-image/dist/src/components/static-image.server';
 import Container from '../../Container';
 import HeroSectionDetails from '../../HeroSectionDetails';
 import ContactUsCta from '../../HeroSectionActions/ContactUsCta';
 import { wrapper } from './styles.module.less';
-
-const commonProps: Partial<IStaticImageProps> = {
-    placeholder: 'blurred',
-    loading: 'eager',
-};
 
 const Hero = () => (
     <section className={wrapper}>
@@ -35,80 +29,6 @@ const Hero = () => (
                 loading="eager"
             />
         </Container>
-        <h2>Featured customers</h2>
-        <ul>
-            <li key="coalesce">
-                <StaticImage
-                    src="../../../images/customer-logos/coalesce.png"
-                    alt="Coalesce logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="flashpack">
-                <StaticImage
-                    src="../../../images/customer-logos/flashpack.svg"
-                    alt="Flash Pack logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="shp">
-                <StaticImage
-                    src="../../../images/customer-logos/shp.svg"
-                    alt="SHP logo"
-                    color="var(--white)"
-                    {...commonProps}
-                />
-            </li>
-            <li key="fenestra">
-                <StaticImage
-                    src="../../../images/customer-logos/fenestra.png"
-                    alt="Fenestra logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="deep-sync">
-                <StaticImage
-                    src="../../../images/customer-logos/deep-sync.png"
-                    alt="Deep Sync logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="excess-telecom">
-                <StaticImage
-                    src="../../../images/customer-logos/excess-telecom.png"
-                    alt="Excess Telecom logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="flock-freight">
-                <StaticImage
-                    src="../../../images/customer-logos/flock-freight.png"
-                    alt="Flock Freight logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="launch-metrics">
-                <StaticImage
-                    src="../../../images/customer-logos/launch-metrics.png"
-                    alt="Launch Metrics logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="chili-piper">
-                <StaticImage
-                    src="../../../images/customer-logos/chili-piper.png"
-                    alt="Chili Piper logo"
-                    {...commonProps}
-                />
-            </li>
-            <li key="revunit">
-                <StaticImage
-                    src="../../../images/customer-logos/revunit.png"
-                    alt="Revunit logo"
-                    {...commonProps}
-                />
-            </li>
-        </ul>
     </section>
 );
 

--- a/src/components/SuccessStoriesPage/SuccessStories/index.tsx
+++ b/src/components/SuccessStoriesPage/SuccessStories/index.tsx
@@ -1,23 +1,40 @@
-import { useState } from 'react';
+// src/components/SuccessStories/index.tsx
+import { useMemo, useState } from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
+import lunr, { type Index } from 'lunr';
 import Container from '../../Container';
 import Grid from '../../Grid';
 import Card from '../../Grid/Card';
 import ButtonFilled from '../../LinksAndButtons/ButtonFilled';
-import { sectionTitle } from '../styles.module.less';
-import { getSlugifiedText, getSortedSuccessStories } from '../../../../shared';
+import { sectionTitle, searchInput, grid } from '../styles.module.less';
+import {
+    getSlugifiedText,
+    getSortedSuccessStories,
+    searchIndex,
+} from '../../../../shared';
+import SearchInput from '../../SearchInput';
 
 const SuccessStories = () => {
     const {
         allStrapiCaseStudy: { nodes: successStories },
+        localSearchCases,
     } = useStaticQuery(graphql`
         query GetSuccessStories {
+            localSearchCases {
+                index
+                store
+            }
             allStrapiCaseStudy(sort: { createdAt: DESC }) {
                 nodes {
                     title: Title
                     description: Description
                     slug: Slug
                     id
+                    tags {
+                        Name
+                        Slug
+                        Type
+                    }
                     hero: Logo {
                         alternativeText
                         localFile {
@@ -38,32 +55,60 @@ const SuccessStories = () => {
 
     const sortedSuccessStories = getSortedSuccessStories(successStories);
 
-    const [visiblePostsAmount, setVisiblePostsAmount] = useState(9);
-
+    const [visibleSuccessStoriesAmount, setVisibleSuccessStoriesAmount] =
+        useState(9);
     const handleShowMore = () => {
-        setVisiblePostsAmount(
-            (prevVisiblePostsAmount) => prevVisiblePostsAmount + 9
-        );
+        setVisibleSuccessStoriesAmount((prev) => prev + 9);
     };
+
+    const index: Index = useMemo(
+        () => lunr.Index.load(JSON.parse(localSearchCases.index)),
+        [localSearchCases.index]
+    );
+
+    const [query, setQuery] = useState('');
+    const handleQueryChange = (evt: React.ChangeEvent<HTMLInputElement>) =>
+        setQuery(evt.target.value);
+
+    const results = useMemo(
+        () => searchIndex(index, localSearchCases.store, query),
+        [query, index, localSearchCases.store]
+    );
+
+    const successStoriesToRender =
+        query.length > 0 ? results : sortedSuccessStories;
+    const noSearchResultsFound = query.length > 0 && results.length === 0;
 
     return (
         <section>
             <Container isVertical>
                 <h2 className={sectionTitle}>Success stories</h2>
-                <Grid>
-                    {sortedSuccessStories
-                        .slice(0, visiblePostsAmount)
-                        .map((successStory) => (
-                            <Card
-                                key={successStory.id}
-                                data={successStory}
-                                footerTag="Success story"
-                                hasImgBackground
-                                linkId={`${getSlugifiedText(successStory.title)}-card-button/success-stories-page`}
-                            />
-                        ))}
-                </Grid>
-                {visiblePostsAmount < successStories.length ? (
+                <SearchInput
+                    placeholder="Search success stories"
+                    handleQueryChange={handleQueryChange}
+                    className={searchInput}
+                />
+
+                {noSearchResultsFound ? (
+                    <p>No results found.</p>
+                ) : (
+                    <Grid className={grid}>
+                        {successStoriesToRender
+                            .slice(0, visibleSuccessStoriesAmount)
+                            .map((successStory) => (
+                                <Card
+                                    key={successStory.id}
+                                    data={successStory}
+                                    footerTag="Success story"
+                                    hasImgBackground
+                                    linkId={`${getSlugifiedText(successStory.title)}-card-button/success-stories-page`}
+                                />
+                            ))}
+                    </Grid>
+                )}
+
+                {visibleSuccessStoriesAmount < successStoriesToRender.length &&
+                !noSearchResultsFound ? (
                     <ButtonFilled onClick={handleShowMore}>
                         Show more
                     </ButtonFilled>

--- a/src/components/SuccessStoriesPage/SuccessStories/index.tsx
+++ b/src/components/SuccessStoriesPage/SuccessStories/index.tsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import lunr, { type Index } from 'lunr';
+import { Alert } from '@mui/material';
 import Container from '../../Container';
 import Grid from '../../Grid';
 import Card from '../../Grid/Card';
@@ -77,7 +78,8 @@ const SuccessStories = () => {
 
     const successStoriesToRender =
         query.length > 0 ? results : sortedSuccessStories;
-    const noSearchResultsFound = query.length > 0 && results.length === 0;
+
+    const noSuccessStoriesFound = query.length > 0 && results.length < 1;
 
     return (
         <section>
@@ -89,8 +91,8 @@ const SuccessStories = () => {
                     className={searchInput}
                 />
 
-                {noSearchResultsFound ? (
-                    <p>No results found.</p>
+                {noSuccessStoriesFound ? (
+                    <Alert severity="info">No success stories found.</Alert>
                 ) : (
                     <Grid className={grid}>
                         {successStoriesToRender
@@ -108,7 +110,7 @@ const SuccessStories = () => {
                 )}
 
                 {visibleSuccessStoriesAmount < successStoriesToRender.length &&
-                !noSearchResultsFound ? (
+                !noSuccessStoriesFound ? (
                     <ButtonFilled onClick={handleShowMore}>
                         Show more
                     </ButtonFilled>

--- a/src/components/SuccessStoriesPage/styles.module.less
+++ b/src/components/SuccessStoriesPage/styles.module.less
@@ -16,3 +16,19 @@
     color: var(--blue);
   }
 }
+
+.searchInput {
+  margin-right: auto;
+}
+
+.grid {
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+
+  li {
+    height: 100%;
+  }
+
+  @media (max-width: 425px) {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/templates/blog/index.tsx
+++ b/src/templates/blog/index.tsx
@@ -120,7 +120,7 @@ const BlogIndex = ({
 
                 <Grid className={blogsIndexBody}>
                     {query.length > 0 && results.length < 1 ? (
-                        <Alert severity="info">No blog posts found</Alert>
+                        <Alert severity="info">No blog posts found.</Alert>
                     ) : null}
 
                     {postsToRender.map((post, idx) => (


### PR DESCRIPTION
#834

## Changes

-   Add search for success stories on success stories page;
-   Drop "Featured customers" section from the same page;
-   Add a "No success stories found" when search results is empty.

## Tests / Screenshots

- Desktop
<img width="697" alt="image" src="https://github.com/user-attachments/assets/4d8e1545-c2ec-4fff-9b5b-207b44bad1c0" />

- Desktop (searching):
<img width="690" alt="image" src="https://github.com/user-attachments/assets/8e61ae9d-ce1c-478e-82e2-29a1171efb43" />

- Mobile
<img width="437" alt="image" src="https://github.com/user-attachments/assets/0d5d9030-2092-4e9c-804b-6b4ccefc0626" />