### PR TITLE
Centralize images on success story body

### DIFF
--- a/src/templates/success-story/styles.module.less
+++ b/src/templates/success-story/styles.module.less
@@ -133,6 +133,10 @@
         display: flex;
         flex-direction: column;
         gap: 16px;
+
+        img {
+            max-height: 400px;
+        }
     }
 
     h1,


### PR DESCRIPTION
#849

## Changes

-   Set a max height to the body images.

## Tests / Screenshots

-   Tested all of them locally and they look good. Example:

Cosuno:
<img width="463" alt="image" src="https://github.com/user-attachments/assets/9713f052-4623-4a62-8877-fd9b7b8530ea" />