### PR TITLE
Add related articles for blogs

### DIFF
--- a/src/components/BlogPopularArticles/index.tsx
+++ b/src/components/BlogPopularArticles/index.tsx
@@ -64,6 +64,7 @@ export const PopularArticles = () => {
                         data={{ ...rest, id, title, slug: `/blog/${slug}` }}
                         footerTag="Article"
                         linkId={`${getSlugifiedText(title)}-popular-article/blog-post-page`}
+                        target="_blank"
                     />
                 )
             )}

--- a/src/components/BlogPost/ArticleCardsSection/index.tsx
+++ b/src/components/BlogPost/ArticleCardsSection/index.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { container } from './styles.module.less';
+
+interface ArticleCardsSectionProps {
+    sectionTitle: string;
+    articleCards: ReactNode;
+}
+
+const ArticleCardsSection = ({
+    sectionTitle,
+    articleCards,
+}: ArticleCardsSectionProps) => {
+    return (
+        <section>
+            <div className={container}>
+                <h2>{sectionTitle}</h2>
+                {articleCards}
+            </div>
+        </section>
+    );
+};
+
+export default ArticleCardsSection;

--- a/src/components/BlogPost/ArticleCardsSection/index.tsx
+++ b/src/components/BlogPost/ArticleCardsSection/index.tsx
@@ -1,20 +1,19 @@
-import { ReactNode } from 'react';
+import { FC } from 'react';
 import { container } from './styles.module.less';
 
 interface ArticleCardsSectionProps {
     sectionTitle: string;
-    articleCards: ReactNode;
 }
 
-const ArticleCardsSection = ({
+const ArticleCardsSection: FC<ArticleCardsSectionProps> = ({
     sectionTitle,
-    articleCards,
-}: ArticleCardsSectionProps) => {
+    children,
+}) => {
     return (
         <section>
             <div className={container}>
                 <h2>{sectionTitle}</h2>
-                {articleCards}
+                {children}
             </div>
         </section>
     );

--- a/src/components/BlogPost/ArticleCardsSection/styles.module.less
+++ b/src/components/BlogPost/ArticleCardsSection/styles.module.less
@@ -1,0 +1,16 @@
+@import '../../../globalStyles/sections.module.less';
+
+.container {
+  .globalMaxWidth;
+
+  h2 {
+    color: var(--grey);
+    font-size: 2.25rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 43.2px;
+    margin-top: 0;
+    margin-bottom: 36px;
+    text-align: center;
+  }
+}

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -324,18 +324,16 @@ const BlogPost = ({
                 </section>
             ) : null}
             {post?.relatedPosts?.length > 0 ? (
-                <ArticleCardsSection
-                    sectionTitle="Related Articles"
-                    articleCards={
-                        <RelatedArticles posts={post?.relatedPosts} />
-                    }
-                />
+                <ArticleCardsSection sectionTitle="Related Articles">
+                    <RelatedArticles
+                        relatedPosts={post?.relatedPosts.slice(0, 3)}
+                    />
+                </ArticleCardsSection>
             ) : null}
             {hasPopularArticlesSection ? (
-                <ArticleCardsSection
-                    sectionTitle="Popular Articles"
-                    articleCards={<PopularArticles />}
-                />
+                <ArticleCardsSection sectionTitle="Popular Articles">
+                    <PopularArticles />
+                </ArticleCardsSection>
             ) : null}
             <section>
                 <div className={bigBuildPipelineBannerWrapper}>

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -25,6 +25,7 @@ import StraightLinesBackground from '../../components/BackgroundImages/StraightL
 import { PopularArticles } from '../../components/BlogPopularArticles';
 import { costPerGB } from '../../utils';
 import ShareArticle from '../ShareArticle';
+import RelatedArticles from '../RelatedArticles';
 import {
     article,
     blogPostHeaderWrapper,
@@ -40,7 +41,6 @@ import {
     blogPostContentWrapper,
     mainContent,
     bigBuildPipelineBannerContainer,
-    popularArticlesWrapper,
     bigBuildPipelineBannerWrapper,
     bigBuildPipelineBannerContainerLayout,
     straightLinesBackgroundWrapper,
@@ -58,6 +58,7 @@ import {
     authorRole,
 } from './styles.module.less';
 import Faqs from './Faqs';
+import ArticleCardsSection from './ArticleCardsSection';
 
 interface BlogPostProps {
     post: any;
@@ -322,13 +323,19 @@ const BlogPost = ({
                     </div>
                 </section>
             ) : null}
+            {post?.relatedPosts?.length > 0 ? (
+                <ArticleCardsSection
+                    sectionTitle="Related Articles"
+                    articleCards={
+                        <RelatedArticles posts={post?.relatedPosts} />
+                    }
+                />
+            ) : null}
             {hasPopularArticlesSection ? (
-                <section>
-                    <div className={popularArticlesWrapper}>
-                        <h2>Popular Articles</h2>
-                        <PopularArticles />
-                    </div>
-                </section>
+                <ArticleCardsSection
+                    sectionTitle="Popular Articles"
+                    articleCards={<PopularArticles />}
+                />
             ) : null}
             <section>
                 <div className={bigBuildPipelineBannerWrapper}>

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -329,21 +329,6 @@
   overflow: hidden;
 }
 
-.popularArticlesWrapper {
-  .globalMaxWidth;
-
-  h2 {
-    color: var(--grey);
-    font-size: 2.25rem;
-    font-style: normal;
-    font-weight: 700;
-    line-height: 43.2px;
-    margin-top: 0;
-    margin-bottom: 36px;
-    text-align: center;
-  }
-}
-
 .bigBuildPipelineBannerContainerLayout {
   display: flex;
   align-items: flex-start;

--- a/src/components/RelatedArticles/index.tsx
+++ b/src/components/RelatedArticles/index.tsx
@@ -1,0 +1,24 @@
+import Card from '../Grid/Card';
+import Grid from '../Grid';
+import { getSlugifiedText } from '../../../shared';
+
+interface RelatedArticlesProps {
+    posts: any;
+}
+
+const RelatedArticles = ({ posts }: RelatedArticlesProps) => {
+    return (
+        <Grid>
+            {posts?.nodes?.map(({ id, slug, title, ...rest }: any) => (
+                <Card
+                    key={id}
+                    data={{ ...rest, id, title, slug: `/blog/${slug}` }}
+                    footerTag="Article"
+                    linkId={`${getSlugifiedText(title)}-related-article/blog-post-page`}
+                />
+            ))}
+        </Grid>
+    );
+};
+
+export default RelatedArticles;

--- a/src/components/RelatedArticles/index.tsx
+++ b/src/components/RelatedArticles/index.tsx
@@ -1,22 +1,25 @@
 import Card from '../Grid/Card';
 import Grid from '../Grid';
 import { getSlugifiedText } from '../../../shared';
+import { container } from './styles.module.less';
 
-interface RelatedArticlesProps {
-    posts: any;
-}
+const orderByUpdateDate = (a, b) =>
+    new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
 
-const RelatedArticles = ({ posts }: RelatedArticlesProps) => {
+const RelatedArticles = ({ relatedPosts }) => {
     return (
-        <Grid>
-            {posts?.nodes?.map(({ id, slug, title, ...rest }: any) => (
-                <Card
-                    key={id}
-                    data={{ ...rest, id, title, slug: `/blog/${slug}` }}
-                    footerTag="Article"
-                    linkId={`${getSlugifiedText(title)}-related-article/blog-post-page`}
-                />
-            ))}
+        <Grid className={container}>
+            {[...(relatedPosts || [])]
+                .sort(orderByUpdateDate)
+                .map(({ id, slug, title, ...rest }) => (
+                    <Card
+                        key={id}
+                        data={{ ...rest, id, title, slug: `/blog/${slug}` }}
+                        footerTag="Article"
+                        linkId={`${getSlugifiedText(title)}-related-article/blog-post-page`}
+                        target="_blank"
+                    />
+                ))}
         </Grid>
     );
 };

--- a/src/components/RelatedArticles/styles.module.less
+++ b/src/components/RelatedArticles/styles.module.less
@@ -1,0 +1,14 @@
+.container {
+  li {
+    width: 100%;
+  }
+
+  @media (min-width: 1056px) {
+    justify-content: center;
+
+    &:has(> li:only-child),
+    &:has(> li:nth-child(2):last-child) {
+      grid-template-columns: repeat(auto-fit, 410px);
+    }
+  }
+}

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -200,10 +200,11 @@ export const pageQuery = graphql`
                 name: Name
                 type: Type
             }
-            relatedPosts: RelatedPosts(sort: { publishedAt: DESC }) {
+            relatedPosts: RelatedPosts {
                 id
                 title: Title
                 slug: Slug
+                updatedAt(formatString: "MMMM D, YYYY")
                 authors {
                     id
                     name: Name

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -200,6 +200,41 @@ export const pageQuery = graphql`
                 name: Name
                 type: Type
             }
+            relatedPosts: RelatedPosts(sort: { publishedAt: DESC }) {
+                id
+                title: Title
+                slug: Slug
+                authors {
+                    id
+                    name: Name
+                    picture: Picture {
+                        localFile {
+                            childImageSharp {
+                                gatsbyImageData(
+                                    layout: CONSTRAINED
+                                    placeholder: BLURRED
+                                    quality: 100
+                                )
+                                fixedImg: gatsbyImageData(
+                                    layout: FIXED
+                                    width: 60
+                                )
+                            }
+                        }
+                    }
+                }
+                hero: Hero {
+                    localFile {
+                        childImageSharp {
+                            gatsbyImageData(
+                                layout: FULL_WIDTH
+                                placeholder: BLURRED
+                                formats: [AUTO, WEBP, AVIF]
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 `;


### PR DESCRIPTION
#869

## Changes

-   Add related articles section above the popular articles section;
-   Improve responsiveness to mobile device screens;
-   Order by `updatedAt` date;
-   Allow at most 3 to be displayed.

## Tests / Screenshots
- Tested locally and looks good.
<img width="491" alt="image" src="https://github.com/user-attachments/assets/836c2d63-d873-4cec-8bfe-72c205b9860e" />