### PR TITLE
Add related success story banner to blog post left sidebar

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -62,6 +62,14 @@ const strapiConfig = {
                             },
                         },
                     },
+                    relatedSuccessStories: {
+                        fields: ['id', 'Title', 'Slug', 'Description'],
+                        populate: {
+                            Logo: {
+                                fields: ['url', 'alternativeText'],
+                            },
+                        },
+                    },
                     tags: {
                         fields: ['Name', 'Slug', 'Type', 'IsTab'],
                     },

--- a/src/components/ArticleSidebar/styles.module.less
+++ b/src/components/ArticleSidebar/styles.module.less
@@ -1,18 +1,19 @@
 .container {
   display: flex;
   flex-direction: column;
-  width: 256px;
   gap: 24px;
   height: fit-content;
 
-  @media (max-width: 1024px) {
+  @media (min-width: 1025px) {
     width: 100%;
-  }
-
-  @media (min-width: 1151px) {
+    max-width: 256px;
+    min-width: 155px;
     position: sticky;
     top: 100px;
-    height: calc(100vh - 124px);
+  }
+
+  @media (max-width: 1024px) {
+    width: 100%;
   }
 
   @media (max-width: 767px) {

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -199,7 +199,12 @@ const BlogPost = ({
                                 </div>
                                 <hr />
                                 <p>{post.relatedSuccessStories.description}.</p>
-                                <LinkFilled>Read Success Story</LinkFilled>
+                                <LinkFilled
+                                    href={`/success-stories/${post.relatedSuccessStories.slug}`}
+                                    target="_blank"
+                                >
+                                    Read Success Story
+                                </LinkFilled>
                             </div>
                         ) : null}
                         <div className={mainContent}>

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -4,6 +4,7 @@ import DoneIcon from '@mui/icons-material/Done';
 import { Divider, useTheme } from '@mui/material';
 import { Link } from 'gatsby';
 import { Fragment } from 'react';
+import clsx from 'clsx';
 import SwoopingLinesBackground from '../BackgroundImages/LightSwoopingLinesRightDirectionBackground';
 import Bio from '../Bio';
 import ReadingTimeIcon from '../../svgs/time.svg';
@@ -26,6 +27,7 @@ import { PopularArticles } from '../../components/BlogPopularArticles';
 import { costPerGB } from '../../utils';
 import ShareArticle from '../ShareArticle';
 import RelatedArticles from '../RelatedArticles';
+import LinkFilled from '../LinksAndButtons/LinkFilled';
 import {
     article,
     blogPostHeaderWrapper,
@@ -39,6 +41,10 @@ import {
     heroImage,
     shareArticleMobile,
     blogPostContentWrapper,
+    blogPostContentWrapperFullWidth,
+    leftSidebar,
+    leftSidebarHeader,
+    leftSidebarImgWrapper,
     mainContent,
     bigBuildPipelineBannerContainer,
     bigBuildPipelineBannerWrapper,
@@ -166,7 +172,36 @@ const BlogPost = ({
             </SwoopingLinesBackground>
             {post.body ? (
                 <section>
-                    <div className={blogPostContentWrapper}>
+                    <div
+                        className={clsx(
+                            blogPostContentWrapper,
+                            post?.relatedSuccessStories
+                                ? blogPostContentWrapperFullWidth
+                                : null
+                        )}
+                    >
+                        {post?.relatedSuccessStories ? (
+                            <div className={leftSidebar}>
+                                <div className={leftSidebarHeader}>
+                                    <div className={leftSidebarImgWrapper}>
+                                        <GatsbyImage
+                                            alt={`${post.relatedSuccessStories.logo.alternativeText} logo`}
+                                            image={
+                                                post.relatedSuccessStories.logo
+                                                    .localFile.childImageSharp
+                                                    .gatsbyImageData
+                                            }
+                                        />
+                                    </div>
+                                    <span>
+                                        {post.relatedSuccessStories.title}
+                                    </span>
+                                </div>
+                                <hr />
+                                <p>{post.relatedSuccessStories.description}.</p>
+                                <LinkFilled>Read Success Story</LinkFilled>
+                            </div>
+                        ) : null}
                         <div className={mainContent}>
                             <ProcessedPost
                                 body={post.body.data.childHtmlRehype.html}

--- a/src/components/BlogPost/index.tsx
+++ b/src/components/BlogPost/index.tsx
@@ -185,7 +185,7 @@ const BlogPost = ({
                                 <div className={leftSidebarHeader}>
                                     <div className={leftSidebarImgWrapper}>
                                         <GatsbyImage
-                                            alt={`${post.relatedSuccessStories.logo.alternativeText} logo`}
+                                            alt={`${post.relatedSuccessStories.logo.alternativeText} success story logo`}
                                             image={
                                                 post.relatedSuccessStories.logo
                                                     .localFile.childImageSharp

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -256,6 +256,8 @@
   flex-direction: column;
   gap: 32px;
   max-width: 1280px;
+  min-width: 560px;
+  overflow: hidden;
 
   @media (max-width: 1024px) {
     width: 100%;

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -181,12 +181,81 @@
   width: 100%;
 }
 
+.blogPostContentWrapperFullWidth {
+  @media (min-width: 1025px) {
+    padding-left: ~'calc(min(10vw,30px))';
+    padding-right: ~'calc(min(10vw,30px))';
+    max-width: ~'calc(1280px + 2 * min(10vw,256px) + 2 * 30px + 2 * 48px)';
+  }
+}
+
+.leftSidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--blue-30-opacity);
+  background-color: var(--blue-15-opacity);
+  border-radius: 12px;
+  padding: 18px;
+  width: 100%;
+  max-width: 256px;
+  min-width: 155px;
+  height: fit-content;
+
+  p {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  hr {
+    height: 1px;
+    background: var(--blue-30-opacity);
+    width: 100%;
+  }
+
+  a {
+    margin-top: 9px;
+    font-size: 0.875rem;
+    padding: 8px 14px;
+  }
+
+  @media (min-width: 1025px) {
+    position: sticky;
+    top: 100px;
+  }
+
+  @media (max-width: 1024px) {
+    display: none;
+  }
+}
+
+.leftSidebarHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+
+
+  span {
+    font-weight: 600;
+    font-size: 1.125rem;
+    line-height: 120%;
+  }
+}
+
+.leftSidebarImgWrapper {
+  width: 64px;
+  max-height: 64px;
+  display: flex;
+  align-items: center;
+}
+
 .mainContent {
-  width: calc(100% - 256px - 48px);
-  padding-left: 48px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 32px;
+  max-width: 1280px;
 
   @media (max-width: 1024px) {
     width: 100%;

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -256,8 +256,11 @@
   flex-direction: column;
   gap: 32px;
   max-width: 1280px;
-  min-width: 560px;
   overflow: hidden;
+
+  @media (min-width: 1025px) {
+      min-width: 560px;
+  }
 
   @media (max-width: 1024px) {
     width: 100%;

--- a/src/components/BlogPost/styles.module.less
+++ b/src/components/BlogPost/styles.module.less
@@ -259,7 +259,7 @@
   overflow: hidden;
 
   @media (min-width: 1025px) {
-      min-width: 560px;
+    min-width: 560px;
   }
 
   @media (max-width: 1024px) {

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -236,6 +236,20 @@ export const pageQuery = graphql`
                     }
                 }
             }
+            relatedSuccessStories {
+                id
+                slug: Slug
+                title: Title
+                description: Description
+                logo: Logo {
+                    alternativeText
+                    localFile {
+                        childImageSharp {
+                            gatsbyImageData
+                        }
+                    }
+                }
+            }
         }
     }
 `;


### PR DESCRIPTION
#870 

## Changes

-   Add related success story banner to blog post left sidebar;
-   Use success story logo, title, slug and description;
-   Allow only one banner.

## Tests / Screenshots

Three blog posts with three different related success stories were tested - content already in Strapi production environment:

-  Normal size screen:

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/1335c70d-d330-4ea7-8501-95b973c0ee8b" />

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/6e3026f6-47c2-48ce-b49d-fe303f9ed1f3" />

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/73b4a0a8-3e76-447c-93b5-a6170ed513e3" />

-  Wide size screen:

<img width="834" alt="image" src="https://github.com/user-attachments/assets/880709b2-1207-45af-8e1b-12ff20a55d0a" />

- Mobile screen:

I removed from mobile screen. The min width to show the banner is 1025px:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/6e09e0ce-689b-4244-8542-750ae28107f7" />

-  I tested the blog posts without related success stories and look good:

<img width="622" alt="image" src="https://github.com/user-attachments/assets/88a28ad2-5326-446b-bae2-0214e6a121d6" />

- I tested the product update pages to make sure it's still okay without the banner and it looks good:

<img width="573" alt="image" src="https://github.com/user-attachments/assets/144b5f76-49f7-4cb7-ac9f-7fb2734d6b0f" />