### PR TITLE
Fix blog banner alt text issue

### DIFF
--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -226,6 +226,7 @@ export const pageQuery = graphql`
                     }
                 }
                 hero: Hero {
+                    alternativeText
                     localFile {
                         childImageSharp {
                             gatsbyImageData(

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -183,6 +183,7 @@ export const pageQuery = graphql`
                 }
             }
             hero: Hero {
+                alternativeText
                 localFile {
                     childImageSharp {
                         gatsbyImageData(


### PR DESCRIPTION
#885

## Changes

-   Add alternative text to blog post hero image;
-   Add alternative text to blog post related article images.

## Tests / Screenshots

<img width="1249" height="768" alt="image" src="https://github.com/user-attachments/assets/cbcf2475-529e-44ce-adbd-c146d5b704f8" />

<img width="1221" height="290" alt="image" src="https://github.com/user-attachments/assets/15c5fbbe-a121-40ce-9efe-054f64524206" />