### PR TITLE
Add benchmark banner to homepage hero section

### DIFF
--- a/src/components/Layout/ReleaseBanner/index.tsx
+++ b/src/components/Layout/ReleaseBanner/index.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import ArrowRight from '../../../svgs/arrow-right.svg';
-import { dashboardRegisterUrl } from '../../../../shared';
 import {
     container,
     darkBackgroundColor,
@@ -22,14 +21,15 @@ const ReleaseBanner = ({ theme = 'dark' }) => {
             <div>
                 <a
                     id="hero-section-banner"
-                    href={dashboardRegisterUrl}
+                    href="/data-warehouse-benchmark-report/"
                     rel="noreferrer"
                     target="_blank"
                 >
-                    <span>Get started</span>
+                    <span>Download the Report</span>
                     <p>
-                        Get 10GB and 2 connectors every month, 100% free — no
-                        strings attached.
+                        2025 Data Warehouse Benchmark - We pushed BigQuery,
+                        Snowflake, Databricks & more to their limits. See who
+                        held up.
                     </p>
                     <ArrowRight color="var(--white)" />
                 </a>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,7 @@ import HowEstuaryMakesADifferenceSection from '../components/HowEstuaryMakesADif
 
 const IndexPage = () => {
     return (
-        <Layout>
+        <Layout showReleaseBanner>
             <Hero />
             <MoveAndTransform />
             <SuccessStories />


### PR DESCRIPTION
#898

## Changes

-   Add requested text and link address;
-   Add banner to homepage only.

## Tests / Screenshots

Tested locally and clicking the banner opens a new tab for the benchmark page.

<img width="1118" height="769" alt="image" src="https://github.com/user-attachments/assets/be7e2803-e868-48a4-af9e-01451754c3c3" />