### PR TITLE
openid: relaxed CORS headers for openid redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4527,6 +4527,15 @@
         "cleanUrls": true,
         "headers": [
             {
+                "source": "/*/.well-known/openid-configuration",
+                "headers": [
+                    {
+                        "key": "Access-Control-Allow-Origin",
+                        "value": "*"
+                    }
+                ]
+            },
+            {
                 "source": "**/*",
                 "headers": [
                     {


### PR DESCRIPTION
# Label `generate-pr-preview` required before opening PR for preview build

## Changes

- Turns out a relaxed CORS header is sometimes necessary for some consumers of the tokens (works with Google and AWS, but not Azure and in tools like jwt.io)

## Tests / Screenshots

-   scenarios you tested with screenshots
