### PR TITLE
Add case study card for vanity logos

### DIFF
--- a/src/components/Homepage/Hero/index.tsx
+++ b/src/components/Homepage/Hero/index.tsx
@@ -42,7 +42,7 @@ const Hero = () => {
                 <MetricCard value="1 petabyte / month" label="Data moved" />
                 <MetricCard value="99.9%" label="Uptime" />
             </ul>
-            <VanityLogosMarquee />
+            <VanityLogosMarquee pageId="homepage" />
         </section>
     );
 };

--- a/src/components/Homepage/Hero/styles.module.less
+++ b/src/components/Homepage/Hero/styles.module.less
@@ -23,8 +23,8 @@
 }
 
 .container {
-    padding-top: 16px;
-    padding-bottom: 40px;
+    padding-top: 16px !important;
+    padding-bottom: 40px !important;
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -110,7 +110,6 @@
     .globalMaxWidth;
     .sectionTopBottomPadding;
 
-    margin-top: 29px;
     margin-bottom: 0;
     padding-top: 0;
     padding-bottom: 29px;

--- a/src/components/Integration/Hero/index.tsx
+++ b/src/components/Integration/Hero/index.tsx
@@ -133,7 +133,7 @@ const Hero = ({ sourceConnector, destConnector }: Connectors) => {
                     label="Single dataflow"
                 />
             </ul>
-            <VanityLogosMarquee />
+            <VanityLogosMarquee pageId="integration-page" />
         </section>
     );
 };

--- a/src/components/VanityLogosMarquee/index.tsx
+++ b/src/components/VanityLogosMarquee/index.tsx
@@ -2,6 +2,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import Marquee from 'react-fast-marquee';
 import './styles.less';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const VanityLogosMarquee = () => {
     const logos = useStaticQuery(graphql`
@@ -27,6 +28,9 @@ const VanityLogosMarquee = () => {
                             }
                         }
                     }
+                    relatedSuccessStory {
+                        slug: Slug
+                    }
                 }
             }
         }
@@ -39,23 +43,37 @@ const VanityLogosMarquee = () => {
                     const isImageSvg = logo.logo.localFile.extension === 'svg';
                     const imgAltText = 'Customer logo';
 
-                    return isImageSvg ? (
-                        <div key={logo.id} className="vanity-logo">
-                            <img
-                                src={logo.logo.localFile.publicURL}
-                                alt={imgAltText}
-                            />
-                        </div>
-                    ) : (
-                        <div key={logo.id} className="vanity-logo">
-                            <GatsbyImage
-                                alt={imgAltText}
-                                loading="eager"
-                                image={
-                                    logo.logo.localFile.childImageSharp
-                                        .gatsbyImageData
-                                }
-                            />
+                    return (
+                        <div key={logo.id} className="logo-wrapper">
+                            {isImageSvg ? (
+                                <div className="vanity-logo">
+                                    <img
+                                        src={logo.logo.localFile.publicURL}
+                                        alt={imgAltText}
+                                    />
+                                </div>
+                            ) : (
+                                <div className="vanity-logo">
+                                    <GatsbyImage
+                                        alt={imgAltText}
+                                        loading="eager"
+                                        image={
+                                            logo.logo.localFile.childImageSharp
+                                                .gatsbyImageData
+                                        }
+                                    />
+                                </div>
+                            )}
+                            {logo.relatedSuccessStory?.slug ? (
+                                <a
+                                    href={`/success-stories/${logo.relatedSuccessStory.slug}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    Success Story
+                                    <ArrowOutwardIcon />
+                                </a>
+                            ) : null}
                         </div>
                     );
                 })}

--- a/src/components/VanityLogosMarquee/index.tsx
+++ b/src/components/VanityLogosMarquee/index.tsx
@@ -4,7 +4,11 @@ import Marquee from 'react-fast-marquee';
 import './styles.less';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
-const VanityLogosMarquee = () => {
+interface VanityLogosMarqueeProps {
+    pageId: string;
+}
+
+const VanityLogosMarquee = ({ pageId }: VanityLogosMarqueeProps) => {
     const logos = useStaticQuery(graphql`
         {
             allStrapiVanityLogo(
@@ -66,7 +70,7 @@ const VanityLogosMarquee = () => {
                             )}
                             {logo.relatedSuccessStory?.slug ? (
                                 <a
-                                    id={`${logo.relatedSuccessStory.slug}-vanity-logo-link/homepage`}
+                                    id={`${logo.relatedSuccessStory.slug}-vanity-logo-link/${pageId}`}
                                     href={`/success-stories/${logo.relatedSuccessStory.slug}`}
                                     target="_blank"
                                     rel="noreferrer"

--- a/src/components/VanityLogosMarquee/index.tsx
+++ b/src/components/VanityLogosMarquee/index.tsx
@@ -38,7 +38,7 @@ const VanityLogosMarquee = () => {
 
     return (
         <div className="container">
-            <Marquee autoFill>
+            <Marquee autoFill pauseOnHover>
                 {logos.allStrapiVanityLogo.nodes?.map((logo) => {
                     const isImageSvg = logo.logo.localFile.extension === 'svg';
                     const imgAltText = 'Customer logo';

--- a/src/components/VanityLogosMarquee/index.tsx
+++ b/src/components/VanityLogosMarquee/index.tsx
@@ -66,6 +66,7 @@ const VanityLogosMarquee = () => {
                             )}
                             {logo.relatedSuccessStory?.slug ? (
                                 <a
+                                    id={`${logo.relatedSuccessStory.slug}-vanity-logo-link/homepage`}
                                     href={`/success-stories/${logo.relatedSuccessStory.slug}`}
                                     target="_blank"
                                     rel="noreferrer"

--- a/src/components/VanityLogosMarquee/styles.less
+++ b/src/components/VanityLogosMarquee/styles.less
@@ -96,15 +96,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 16px;
   margin-bottom: auto;
 
   a {
     border-radius: 24px;
     background-color: var(--blue-20-opacity);
-    padding: 8px 12px;
+    padding: 6px 10px;
     color: var(--white);
-    font-size: 0.875rem;
+    font-size: 0.8rem;
     display: flex;
     align-items: center;
     gap: 6px;

--- a/src/components/VanityLogosMarquee/styles.less
+++ b/src/components/VanityLogosMarquee/styles.less
@@ -107,7 +107,7 @@
     font-size: 0.8rem;
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 5px;
     transition: var(--default-transition);
 
     svg {

--- a/src/components/VanityLogosMarquee/styles.less
+++ b/src/components/VanityLogosMarquee/styles.less
@@ -1,5 +1,4 @@
 .container {
-  height: 74px;
   width: 100%;
   display: flex;
   overflow-y: hidden;
@@ -63,6 +62,10 @@
   .rfm-marquee:first-child {
     margin-right: 100px;
   }
+
+  .rfm-child {
+    margin-bottom: auto;
+  }
 }
 
 .vanity-logo {
@@ -86,5 +89,33 @@
 
   .slick-slide {
     width: 130px !important;
+  }
+}
+
+.logo-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: auto;
+
+  a {
+    border-radius: 24px;
+    background-color: var(--blue-20-opacity);
+    padding: 8px 12px;
+    color: var(--white);
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: var(--default-transition);
+
+    svg {
+      width: 14px;
+    }
+
+    &:hover {
+      background-color: var(--blue-30-opacity);
+    }
   }
 }


### PR DESCRIPTION
#903

## Changes

-   Add respective success story links to each vanity logo on marquee present on home and integration pages;
-   Improve spacings on the homepage hero section.

## Tests / Screenshots

- Desktop
<img width="697" height="526" alt="image" src="https://github.com/user-attachments/assets/35b08575-80b2-4a2e-b8de-ef594f728636" />

- Mobile
<img width="475" height="649" alt="image" src="https://github.com/user-attachments/assets/33218319-c65c-4439-a28a-f3633e95186c" />

- Hover effect (left one was hovered while right one normal):
<img width="537" height="162" alt="image" src="https://github.com/user-attachments/assets/afd7e88d-4b1d-4c29-99c1-a47b4c687188" />