### PR TITLE
Make some strapi seed data adaptations

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -143,6 +143,10 @@ const createVendorCompare: CreateHelper = async (
 
     // Loop and process what we got (ignore blogs cause that is big and handled down below)
     if (vendors) {
+        const estuary = vendors.find((vendor) =>
+            vendor.slugKey?.includes('estuary')
+        );
+
         vendors.forEach((xVendor, i) => {
             vendors.slice(i + 1).forEach((yVendor) => {
                 if (xVendor.slugKey && yVendor.slugKey) {
@@ -155,8 +159,7 @@ const createVendorCompare: CreateHelper = async (
                         context: {
                             xVendorId: xVendor.id,
                             yVendorId: yVendor.id,
-                            estuaryVendorId:
-                                'd829928c-c473-5421-ac0a-f03c45b14993',
+                            estuaryVendorId: estuary?.id,
                         },
                     });
                 }

--- a/src/components/ProductPage/KeyFeatures/features.tsx
+++ b/src/components/ProductPage/KeyFeatures/features.tsx
@@ -45,9 +45,9 @@ export const features: { [key: string]: Features } = {
         title: 'Real-time and batch',
         description: (
             <p>
-                Connect apps, analytics, and AI using 100s of streaming CDC,
-                real-time, and batch no-code connectors built by Estuary for
-                speed and scale.
+                Stream data from each source, then load each destination at any
+                speed, from &lt;100ms for operations or hour+ intervals, for
+                analytics.
             </p>
         ),
     },

--- a/src/pages/etl-tools/index.tsx
+++ b/src/pages/etl-tools/index.tsx
@@ -62,9 +62,7 @@ export default EtlTools;
 
 export const pageQuery = graphql`
     query GetAllComparisons {
-        estuaryVendor: strapiComparison(
-            id: { eq: "d829928c-c473-5421-ac0a-f03c45b14993" }
-        ) {
+        estuaryVendor: strapiComparison(slugKey: { in: "estuary" }) {
             id
         }
         vendors: allStrapiComparison(sort: { Vendor_Name: ASC }) {


### PR DESCRIPTION
Related strapi admin PR: https://github.com/estuary/strapi-admin/pull/94

## Changes

-   Use estuary vendor `slugKey` instead of `id` to check if it's estuary vendor or not;
-   Off topic: Leverage this PR to fix a text from product page.

## Tests / Screenshots

Before:
<img width="623" height="822" alt="image" src="https://github.com/user-attachments/assets/3d0bd6ae-e050-423b-b0e6-e5e308d0ac64" />

Then:
<img width="641" height="824" alt="image" src="https://github.com/user-attachments/assets/171c19cd-9c91-41a1-b43d-8561b5db7239" />

For the comparison pages, I tested with local Strapi seed data and prod data and they look good:

<img width="935" height="830" alt="image" src="https://github.com/user-attachments/assets/8aa01487-bb61-4f1a-b5c0-0b6e6d7a4832" />

<img width="967" height="816" alt="image" src="https://github.com/user-attachments/assets/05ed6d3c-a420-4414-a1b6-be0d80da10db" />
