### PR TITLE
Fix sitemap deployment

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -933,7 +933,6 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({
     reporter,
 }) => {
     try {
-        // Query all pages to generate sitemaps
         const result = await graphql<{
             site: {
                 siteMetadata: {
@@ -978,7 +977,6 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({
         console.log('Sitemap generation - publicPath:', publicPath);
         console.log('Sitemap generation - process.cwd():', process.cwd());
 
-        // Generate custom sitemaps
         await generateCustomSitemaps(pages, publicPath);
 
         reporter.success('Custom sitemaps generated successfully');

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -973,7 +973,10 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({
         }
 
         const pages = result.data?.allSitePage.nodes ?? [];
-        const publicPath = './public';
+        const publicPath = path.resolve(process.cwd(), 'public');
+
+        console.log('Sitemap generation - publicPath:', publicPath);
+        console.log('Sitemap generation - process.cwd():', process.cwd());
 
         // Generate custom sitemaps
         await generateCustomSitemaps(pages, publicPath);

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -1,5 +1,4 @@
 import { createWriteStream } from 'fs';
-import { mkdir } from 'fs/promises';
 import * as path from 'path';
 import {
     SitemapStream,
@@ -188,8 +187,6 @@ export const generateCustomSitemaps = async (
     publicPath: string
 ): Promise<void> => {
     try {
-        await mkdir(publicPath, { recursive: true });
-
         const integrationUrls: SitemapUrl[] = [];
         const otherUrls: SitemapUrl[] = [];
 

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -172,7 +172,7 @@ export const generateCustomSitemaps = async (
                 'integrations-sitemap'
             );
             console.log(
-                `Generated integrations sitemap with ${integrationUrls.length} URLs`
+                `Generated integrations sitemap with ${integrationUrls.length} URLs at ${publicPath}`
             );
         }
 
@@ -183,7 +183,7 @@ export const generateCustomSitemaps = async (
                 'sitemap-0'
             );
             console.log(
-                `Generated main sitemap with ${sortedOtherUrls.length} URLs`
+                `Generated main sitemap with ${sortedOtherUrls.length} URLs at ${publicPath}`
             );
         }
         console.log('Generated sitemap index');

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -1,7 +1,11 @@
 import { createWriteStream } from 'fs';
 import { mkdir } from 'fs/promises';
 import * as path from 'path';
-import { SitemapStream, SitemapAndIndexStream, SitemapIndexStream } from 'sitemap';
+import {
+    SitemapStream,
+    SitemapAndIndexStream,
+    SitemapIndexStream,
+} from 'sitemap';
 
 interface SitemapUrl {
     url: string;
@@ -90,7 +94,9 @@ const convertToSitemapUrl = (page: PageData): SitemapUrl => {
     };
 };
 
-const waitForStreamFinish = (writeStream: NodeJS.WritableStream): Promise<void> => {
+const waitForStreamFinish = (
+    writeStream: NodeJS.WritableStream
+): Promise<void> => {
     return new Promise((resolve, reject) => {
         writeStream.on('finish', resolve);
         writeStream.on('error', reject);
@@ -120,11 +126,7 @@ const generateLargeSitemap = async (
             const fullPath = path.join(publicPath, sitemapPath);
             const ws = sitemapStream.pipe(createWriteStream(fullPath));
 
-            return [
-                `${siteUrl}/${sitemapPath}`,
-                sitemapStream,
-                ws,
-            ];
+            return [`${siteUrl}/${sitemapPath}`, sitemapStream, ws];
         },
     });
 

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -120,8 +120,7 @@ const generateLargeSitemap = async (
                 },
             });
 
-            const sitemapPath =
-                i === 0 ? `${sitemapName}.xml` : `${sitemapName}-${i}.xml`;
+            const sitemapPath = `${sitemapName}-${i}.xml`;
             const fullPath = path.join(publicPath, sitemapPath);
             const ws = sitemapStream.pipe(createWriteStream(fullPath));
 
@@ -159,7 +158,7 @@ const generateMainSitemapIndex = async (
     const writeStream = sitemapIndex.pipe(createWriteStream(indexPath));
 
     for (let i = 0; i < mainSitemapCount; i++) {
-        const sitemapName = i === 0 ? 'sitemap-0.xml' : `sitemap-0-${i}.xml`;
+        const sitemapName = `sitemap-${i}.xml`;
         sitemapIndex.write({
             url: `${siteUrl}/${sitemapName}`,
             lastmod: new Date().toISOString(),
@@ -167,10 +166,7 @@ const generateMainSitemapIndex = async (
     }
 
     for (let i = 0; i < integrationsSitemapCount; i++) {
-        const sitemapName =
-            i === 0
-                ? 'integrations-sitemap.xml'
-                : `integrations-sitemap-${i}.xml`;
+        const sitemapName = `integrations-sitemap-${i}.xml`;
         sitemapIndex.write({
             url: `${siteUrl}/${sitemapName}`,
             lastmod: new Date().toISOString(),


### PR DESCRIPTION
## Description

Fixed an issue where sitemap files were not being properly deployed to the live website. The problem was caused by incorrect file path handling during the build process, which prevented the sitemap files from being included in the final deployment bundle. 

## Changes

-   Changed relative path  `./public` to `path.resolve(process.cwd(), 'public')` in the sitemap generation on `onPostBuild` to ensure absolute path resolution during build. Added debug logging to track file generation paths and confirm successful sitemap creation.

## Tests / Screenshots

Preview:
<img width="824" height="267" alt="image" src="https://github.com/user-attachments/assets/c078c5c3-9976-4d62-9689-30c6df86c800" />

Live:
<img width="646" height="256" alt="image" src="https://github.com/user-attachments/assets/95d5bf03-aae6-4b39-a170-be6d9e58d8d0" />