### PR TITLE
Remove 404 page and changefreq from sitemap

### DIFF
--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -9,7 +9,6 @@ import {
 interface SitemapUrl {
     url: string;
     lastmod?: string;
-    changefreq?: string;
 }
 
 interface PageData {
@@ -84,12 +83,9 @@ const sortUrlsByCategory = (urls: SitemapUrl[]): SitemapUrl[] => {
 };
 
 const convertToSitemapUrl = (page: PageData): SitemapUrl => {
-    const isBlogUrl = page.path.startsWith('/blog');
-
     return {
         url: page.path,
         lastmod: page.pageContext?.lastMod,
-        changefreq: isBlogUrl ? 'weekly' : undefined,
     };
 };
 
@@ -135,7 +131,6 @@ const generateLargeSitemap = async (
         sms.write({
             url: url.url,
             lastmod: url.lastmod,
-            changefreq: url.changefreq,
         });
     });
 

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -51,6 +51,9 @@ const shouldExcludePage = (pagePath: string) => {
     const excludedPaths = [
         '/dev-404-page',
         '/404',
+        '/404/',
+        '/404.html',
+        '/404.html/',
         '/offline-plugin-app-shell-fallback',
     ];
     return excludedPaths.includes(pagePath);


### PR DESCRIPTION
#931

## Changes

-   Remove changefreq from blog posts in the sitemap-0.xml;
-   Remove 404 page paths from the sitemap-0.xml.

## Tests / Screenshots

-   Removed 404:

<img width="1415" height="375" alt="image" src="https://github.com/user-attachments/assets/af310647-39b8-41cc-b642-601445b4b47e" />

-   Removed `changefreq`:

<img width="1427" height="645" alt="image" src="https://github.com/user-attachments/assets/1e4adeb9-abf7-4ab1-a238-5073a4e3af1d" />